### PR TITLE
Fix memory leak in worker error logging

### DIFF
--- a/src/utils/indexer_worker.ts
+++ b/src/utils/indexer_worker.ts
@@ -69,7 +69,14 @@ export class IndexerWorker {
       await this.queue.commit(batch);
       logger.info(`Successfully indexed and committed batch of ${batch.length} documents.`);
     } catch (error) {
-      logger.error('Error processing batch, requeueing.', { error });
+      if (error instanceof Error) {
+        logger.error('Error processing batch, requeueing.', {
+          errorMessage: error.message,
+          errorStack: error.stack,
+        });
+      } else {
+        logger.error('An unknown error occurred while processing a batch.', { error });
+      }
       await this.queue.requeue(batch);
     }
   }


### PR DESCRIPTION
## 🍒 Summary

This pull request fixes a critical memory leak in the indexer worker that occurred during error handling. When an Elasticsearch bulk request failed, the worker was attempting to log the entire error object, which included the massive request payload. This would quickly exhaust the Node.js heap and cause the process to crash. This change modifies the logging to only include the essential error message and stack trace, ensuring stability.

## 🛠️ Changes

- Modify the error logging in the indexer worker to prevent a memory leak.
- The Elasticsearch client error object, which contains the entire request payload, is no longer logged.
- Instead, only the error message and stack trace are logged, preventing the heap from being exhausted.

## 🎙️ Prompts

- "I'm getting this error..."

🤖 This pull request was assisted by Gemini CLI
