### PR TITLE
Add queue:list-failed command for diagnosing failed documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ Resets all documents in a queue with a `failed` status back to `pending`. This i
 npm run queue:retry-failed -- --repo-name=kibana
 ```
 
+### `npm run queue:list-failed`
+
+Lists all documents in a queue that have a `failed` status, showing their ID, content size, and file path. This is useful for diagnosing "poison pill" documents that consistently fail to process.
+
+**Arguments:**
+- `--repo-name=<repo>`: The name of the repository queue to inspect.
+
+**Example:**
+```bash
+npm run queue:list-failed -- --repo-name=kibana
+```
+
 ---
 
 ## MCP Server Integration

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "incremental-index": "ts-node src/index.ts incremental-index",
     "queue:monitor": "ts-node src/index.ts queue:monitor",
     "queue:retry-failed": "ts-node src/index.ts queue:retry-failed",
+    "queue:list-failed": "ts-node src/index.ts queue:list-failed",
     "setup": "ts-node src/index.ts setup",
     "test": "jest"
   },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,3 +7,4 @@ export * from './monitor_queue_command';
 export * from './multi_worker_command';
 export * from './clear_queue_command';
 export * from './retry_failed_command';
+export * from './list_failed_command';

--- a/src/commands/list_failed_command.ts
+++ b/src/commands/list_failed_command.ts
@@ -1,0 +1,66 @@
+import { Command, Option } from 'commander';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { logger } from '../utils/logger';
+import { appConfig } from '../config';
+import { CodeChunk } from '../utils/elasticsearch';
+
+// Helper function to format bytes into a human-readable string
+function formatBytes(bytes: number, decimals = 2): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
+export const listFailedCommand = new Command('queue:list-failed')
+  .description('Lists all documents in a queue with a "failed" status.')
+  .addOption(
+    new Option(
+      '--repo-name <repoName>',
+      'The name of the repository for which to list failed documents.'
+    ).makeOptionMandatory()
+  )
+  .action(async (options) => {
+    const { repoName } = options;
+    const queueDir = path.join(appConfig.queueBaseDir, repoName);
+    const dbPath = path.join(queueDir, 'queue.db');
+
+    try {
+      const db = new Database(dbPath, { readonly: true });
+
+      const selectStmt = db.prepare(`
+        SELECT id, document
+        FROM queue
+        WHERE status = 'failed'
+        ORDER BY id
+      `);
+      
+      const failedDocs = selectStmt.all() as { id: number; document: string }[];
+
+      if (failedDocs.length === 0) {
+        console.log(`No failed documents found in queue '${repoName}'.`);
+        return;
+      }
+
+      console.log(`Found ${failedDocs.length} failed documents in queue '${repoName}':\n`);
+
+      for (const doc of failedDocs) {
+        try {
+          const parsedDoc: CodeChunk = JSON.parse(doc.document);
+          const contentSize = Buffer.byteLength(parsedDoc.content, 'utf8');
+          console.log(`ID: ${doc.id} | Size: ${formatBytes(contentSize)} | Path: ${parsedDoc.filePath}`);
+        } catch (parseError) {
+          console.log(`ID: ${doc.id} | Error: Failed to parse document JSON.`);
+        }
+      }
+      
+      db.close();
+    } catch (error) {
+      logger.error(`Failed to connect to or read the database at ${dbPath}.`, { error });
+      logger.error('Please ensure the --repo-name is correct and the database file exists.');
+      process.exit(1);
+    }
+  });


### PR DESCRIPTION
## 🍒 Summary

This pull request introduces a new `queue:list-failed` command, a diagnostic tool designed to help operators identify and inspect "poison pill" documents that are causing persistent indexing failures. The command lists all documents in the 'failed' state, displaying their ID, content size, and file path, making it easy to pinpoint problematic files.

## 🛠️ Changes

- Create a new `queue:list-failed` command to display information about documents in the failed queue.
- The command outputs the document ID, content size, and file path to help identify "poison pill" documents.
- Update the `README.md` to document the new command.

## 🎙️ Prompts

- "I have the batch size set to 10 on these documents... they are the once that were in the failed queue. I wonder what kind of documents and their paths are?"
- "Yes... what's the output of queue:list-failed goign to be?"

🤖 This pull request was assisted by Gemini CLI
