### PR TITLE
Add opt-in support for dense vector embeddings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export const indexingConfig = {
   maxQueueSize: parseInt(process.env.MAX_QUEUE_SIZE || '1000', 10),
   cpuCores: parseInt(process.env.CPU_CORES || `${Math.max(1, Math.floor(os.cpus().length / 2))}`, 10),
   maxChunkSizeBytes: parseInt(process.env.MAX_CHUNK_SIZE_BYTES || '1000000', 10),
+  enableDenseVectors: process.env.ENABLE_DENSE_VECTORS === 'true',
 };
 
 export const appConfig = {


### PR DESCRIPTION
## 🍒 Summary

This pull request introduces an opt-in feature for generating dense vector embeddings using the `microsoft/codebert-base` model. This allows users to enable a powerful "find similar code" capability at the cost of indexing performance. By default, this feature is disabled to prioritize indexing speed.

## 🛠️ Changes

- Add `enableDenseVectors` feature flag to `indexingConfig`.
- Remove the default ingest pipeline from the index settings.
- Conditionally add the `code-similarity-pipeline` to the bulk request based on the `enableDenseVectors` flag.
- Update `README.md` with instructions on how to enable the dense vector feature.

## 🎙️ Prompts

- "I feel like I had faster thorughput when I wasn't doing 2 embedding... I'm wonder if I really need the Microsoft Codebert dense_vectors in this project. The promise was to do "Find similar code" but I'm not sure that's really needed for an LLM coding assitant."
- "Hum... I think we should remove the default pipeline from the index all together. Then make it so we include the pipeline in the bulk request. That way you could choose to turn it on or off without making changes to the index template."
- "Is there any harm in having the code_vector field in the mappings by default, if it's not used... it doesn't affect anything. If someone trys to use that field they will get an error."

🤖 This pull request was assisted by Gemini CLI
