### PR TITLE
Fix ENOENT error in systemd by using GIT_PATH env var

### DIFF
--- a/COMMIT_MESSAGE.md
+++ b/COMMIT_MESSAGE.md
@@ -1,16 +1,13 @@
-Refactor GCP deployment to simplify worker logic
+Fix ENOENT error in systemd by using GIT_PATH env var
 
-- Removes the persistent, watch-based `indexer-worker@.service`.
-- Deletes the specialized `multi-index-worker` command and its associated files.
-- Consolidates the producer and worker logic into a single, sequential process within the `run_multi_producer.sh` script.
-- The producer script now directly invokes the generic `index-worker` for each repository after enqueuing changes.
-- Updates the `GCP_DEPLOYMENT_GUIDE.md` to reflect the simpler, non-persistent architecture.
-- Adds a `TimeoutStartSec=0` recommendation to the `indexer-producer.service` to handle long-running jobs.
+- Modifies the `incremental-index` command to use a `GIT_PATH` environment variable for executing git commands, preventing `ENOENT` errors in minimal `systemd` environments.
+- Updates the `GCP_DEPLOYMENT_GUIDE.md` to include the new `GIT_PATH` variable in the example `.env` file.
+- Removes the obsolete `multiWorkerCommand` registration from `src/index.ts` that was missed during the previous refactoring.
 
 Prompts:
 
-- "Can you review the GCP_DEPLOYMENT_GUIDE.md along with the different scripts that are called. I feel like when I read the `index-worker@.service` I think that the multi-index-worker will still need to be called with `ELASTICSEARCH_INDEX` to ensure it indexes to the correct Elasticsearch index for the repository."
-- "I feel like we could simplify this even more... why not run `npm run index-worker` immediately after the incremental-index command? It doesn't need to be running continuously. Just after incremental-index runs."
-- "Why not just use index-worker and add QUEUE_DIR and ELASTICSEARCH_INDEX to the command. Then we have less code."
+- "I'm getting this error: ... spawnSync /bin/sh ENOENT"
+- "That doesn't seem to be working..."
+- "Can we just set `GIT_PATH` as and ENV var?"
 
 🤖 This commit was assisted by Gemini CLI

--- a/docs/GCP_DEPLOYMENT_GUIDE.md
+++ b/docs/GCP_DEPLOYMENT_GUIDE.md
@@ -99,6 +99,9 @@ The `REPOSITORIES_TO_INDEX` variable is a space-separated list. Each item is a p
 ```bash
 # /opt/semantic-code-search-indexer/.env
 
+# Path to the git executable (required for systemd service)
+GIT_PATH="/usr/bin/git"
+
 # Elasticsearch Configuration
 ELASTICSEARCH_ENDPOINT="https://your-es-endpoint.elastic-cloud.com:9243"
 ELASTICSEARCH_API_KEY="YourEncodedApiKey"

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   setupCommand, 
   workerCommand, 
   monitorQueueCommand, 
-  multiWorkerCommand, 
+   
   clearQueueCommand,
   retryFailedCommand,
   listFailedCommand
@@ -26,7 +26,7 @@ program.addCommand(incrementalIndexCommand);
 program.addCommand(setupCommand);
 program.addCommand(workerCommand);
 program.addCommand(monitorQueueCommand);
-program.addCommand(multiWorkerCommand);
+
 program.addCommand(clearQueueCommand);
 program.addCommand(retryFailedCommand);
 program.addCommand(listFailedCommand);


### PR DESCRIPTION
## 🍒 Summary

This pull request resolves a critical `ENOENT` (Error: No Entry) bug that occurred when running the indexer as a `systemd` service. The issue was caused by the service's minimal `PATH` environment, which prevented the application from finding the `git` executable.

The fix introduces a new, explicit `GIT_PATH` environment variable, making the dependency clear and ensuring the application can reliably execute git commands regardless of the environment it's run in.

## 🛠️ Changes

- The `incremental-index` command has been updated to prioritize `process.env.GIT_PATH` for executing `git` commands, falling back to the default `git` for local development.
- The `GCP_DEPLOYMENT_GUIDE.md` has been updated to include the new `GIT_PATH` variable in the example `.env` configuration.
- A lingering reference to the deleted `multiWorkerCommand` has been removed from `src/index.ts`.

## 🎙️ Prompts

- "I'm getting this error: ... spawnSync /bin/sh ENOENT"
- "That doesn't seem to be working..."
- "Can we just set `GIT_PATH` as and ENV var?"

🤖 This pull request was assisted by Gemini CLI
