### PR TITLE
Fix ENOENT error by using spawnSync for git commands

### DIFF
--- a/COMMIT_MESSAGE.md
+++ b/COMMIT_MESSAGE.md
@@ -1,13 +1,11 @@
-Fix ENOENT error in systemd by using GIT_PATH env var
+Fix ENOENT error by using spawnSync for git commands
 
-- Modifies the `incremental-index` command to use a `GIT_PATH` environment variable for executing git commands, preventing `ENOENT` errors in minimal `systemd` environments.
-- Updates the `GCP_DEPLOYMENT_GUIDE.md` to include the new `GIT_PATH` variable in the example `.env` file.
-- Removes the obsolete `multiWorkerCommand` registration from `src/index.ts` that was missed during the previous refactoring.
+- Refactors the `incremental-index` command to use `spawnSync` instead of `execSync` for all git operations.
+- This change avoids shell parsing issues and correctly handles paths with spaces, resolving the `ENOENT` error when the `GIT_PATH` environment variable is used.
+- A `runGitCommand` helper function has been introduced to centralize the logic for executing git commands.
 
 Prompts:
 
 - "I'm getting this error: ... spawnSync /bin/sh ENOENT"
-- "That doesn't seem to be working..."
-- "Can we just set `GIT_PATH` as and ENV var?"
 
 🤖 This commit was assisted by Gemini CLI

--- a/src/commands/incremental_index_command.ts
+++ b/src/commands/incremental_index_command.ts
@@ -10,10 +10,23 @@ import { indexingConfig, appConfig } from '../config';
 import path from 'path';
 import { Worker } from 'worker_threads';
 import PQueue from 'p-queue';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { logger } from '../utils/logger';
 import { IQueue } from '../utils/queue';
 import { SqliteQueue } from '../utils/sqlite_queue';
+
+function runGitCommand(args: string[], cwd: string): string {
+  const gitCommand = process.env.GIT_PATH || 'git';
+  const result = spawnSync(gitCommand, args, { cwd, encoding: 'utf-8' });
+
+  if (result.status !== 0) {
+    const errorMessage = result.stderr || result.error?.message || 'Unknown git error';
+    logger.error('Git command failed', { args, errorMessage });
+    throw new Error(errorMessage);
+  }
+
+  return result.stdout.trim();
+}
 
 async function getQueue(): Promise<IQueue> {
   const queue = new SqliteQueue(appConfig.queueDir);
@@ -25,11 +38,7 @@ async function incrementalIndex(directory: string) {
   logger.info('Starting incremental indexing process (Producer)', { directory });
   await setupElser();
 
-  const gitCommand = process.env.GIT_PATH || 'git';
-
-  const gitBranch = execSync(`${gitCommand} rev-parse --abbrev-ref HEAD`, { cwd: directory })
-    .toString()
-    .trim();
+  const gitBranch = runGitCommand(['rev-parse', '--abbrev-ref', 'HEAD'], directory);
   const lastCommitHash = await getLastIndexedCommit(gitBranch);
 
   if (!lastCommitHash) {
@@ -41,7 +50,7 @@ async function incrementalIndex(directory: string) {
 
   logger.info('Pulling latest changes from remote', { gitBranch });
   try {
-    execSync(`${gitCommand} pull origin ${gitBranch}`, { cwd: directory, stdio: 'pipe' });
+    runGitCommand(['pull', 'origin', gitBranch], directory);
     logger.info('Pull complete.');
   } catch (error: unknown) {
     if (error instanceof Error) {
@@ -52,12 +61,8 @@ async function incrementalIndex(directory: string) {
     return;
   }
 
-  const gitRoot = execSync(`${gitCommand} rev-parse --show-toplevel`, { cwd: directory }).toString().trim();
-  const changedFilesRaw = execSync(`${gitCommand} diff --name-status ${lastCommitHash} HEAD`, {
-    cwd: directory,
-  })
-    .toString()
-    .trim();
+  const gitRoot = runGitCommand(['rev-parse', '--show-toplevel'], directory);
+  const changedFilesRaw = runGitCommand(['diff', '--name-status', lastCommitHash, 'HEAD'], directory);
 
   const changedFiles = changedFilesRaw
     .split('\n')
@@ -138,7 +143,7 @@ async function incrementalIndex(directory: string) {
     logger.info(`Failed to parse:      ${failureCount} files`);
   }
 
-  const newCommitHash = execSync(`${gitCommand} rev-parse HEAD`, { cwd: directory }).toString().trim();
+  const newCommitHash = runGitCommand(['rev-parse', 'HEAD'], directory);
   await updateLastIndexedCommit(gitBranch, newCommitHash);
 
   logger.info('---');


### PR DESCRIPTION
## 🍒 Summary

This pull request resolves the persistent `ENOENT` (Error: No Entry) bug encountered when running the indexer as a `systemd` service. The root cause was identified as a shell parsing issue when `execSync` was combined with the `GIT_PATH` environment variable.

The fix replaces all `execSync` calls for git operations with the more robust `spawnSync`. This bypasses the shell entirely, ensuring that the command and its arguments are handled correctly and reliably, thus fixing the error.

## 🛠️ Changes

- All `git` command executions in `incremental_index_command.ts` have been refactored to use `spawnSync`.
- A new `runGitCommand` helper function has been introduced to centralize the logic for executing git commands, checking for errors, and returning trimmed output.

## 🎙️ Prompts

- "I'm getting this error: ... spawnSync /bin/sh ENOENT"

🤖 This pull request was assisted by Gemini CLI
