### PR TITLE
Switch to cron for deployment to fix systemd ENOENT error

### DIFF
--- a/COMMIT_MESSAGE.md
+++ b/COMMIT_MESSAGE.md
@@ -1,15 +1,11 @@
-Refactor producer to TypeScript to fix systemd ENOENT
+Switch to cron for deployment to fix ENOENT
 
-- Resolves a persistent `ENOENT` error by refactoring the producer logic from a shell script (`run_multi_producer.sh`) into a pure TypeScript entrypoint (`src/run_producer.ts`).
-- This avoids the complex and problematic interactions between `systemd` sandboxing and the layers of `sh`, `npm`, and `ts-node`.
-- Creates a new `start:producer` npm script to execute the compiled TypeScript entrypoint.
-- Updates the `GCP_DEPLOYMENT_GUIDE.md` to use the new `npm run start:producer` command in the `systemd` service file.
-- Deletes the now-obsolete `run_multi_producer.sh` script.
+- Replaces the `systemd` service with a `cron` job to resolve a persistent `ENOENT` error caused by `systemd` sandboxing.
+- Updates the `GCP_DEPLOYMENT_GUIDE.md` with instructions for setting up the `cron` job.
+- Fixes a bug in the producer's error logging to ensure error objects are logged as strings.
 
 Prompts:
 
-- "I'm getting this error now: ... spawnSync /usr/bin/git ENOENT"
-- "same error"
-- "Here is the output: ... /usr/bin/git is visible and executable."
+- "What if we changed to just a simple cron?"
 
 🤖 This commit was assisted by Gemini CLI

--- a/src/run_producer.ts
+++ b/src/run_producer.ts
@@ -35,8 +35,9 @@ async function main() {
       await worker();
 
       logger.info(`--- Finished processing for: ${repoName} ---`);
-    } catch (error) {
-      logger.error(`Failed to process repository ${repoName}`, { error });
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      logger.error(`Failed to process repository ${repoName}`, { error: errorMessage });
       // Depending on desired behavior, you might want to continue or exit.
       // For now, we will log the error and continue to the next repo.
     }


### PR DESCRIPTION
## 🍒 Summary

This pull request resolves the persistent `ENOENT` error by replacing the `systemd` service with a standard `cron` job for scheduling. The `systemd` sandboxing environment proved too restrictive for the Node.js runtime's `spawnSync` function, causing the process to fail. Switching to `cron` provides a more conventional and less restrictive execution environment, which is better suited for this type of periodic task.

This change also includes a minor bug fix to ensure that error objects are correctly logged as strings to prevent Elasticsearch mapping conflicts.

## 🛠️ Changes

- The `GCP_DEPLOYMENT_GUIDE.md` has been completely rewritten to use `cron` for scheduling the producer script, removing all `systemd` service and timer file instructions.
- The error logging in `src/run_producer.ts` has been improved to handle different error types and log a clean string message.

## 🎙️ Prompts

- "What if we changed to just a simple cron?"

🤖 This pull request was assisted by Gemini CLI
