### PR TITLE
Revert to execSync for git commands to troubleshoot ENOENT

### DIFF
--- a/COMMIT_MESSAGE.md
+++ b/COMMIT_MESSAGE.md
@@ -1,11 +1,10 @@
-Switch to cron for deployment to fix ENOENT
+Revert to execSync for git commands
 
-- Replaces the `systemd` service with a `cron` job to resolve a persistent `ENOENT` error caused by `systemd` sandboxing.
-- Updates the `GCP_DEPLOYMENT_GUIDE.md` with instructions for setting up the `cron` job.
-- Fixes a bug in the producer's error logging to ensure error objects are logged as strings.
+- Reverts the git command execution in `incremental_index_command.ts` from `spawnSync` back to `execSync`.
+- This is a troubleshooting step to address a persistent `ENOENT` error in a specific remote environment.
 
 Prompts:
 
-- "What if we changed to just a simple cron?"
+- "can we go back to the original git command that worked"
 
 🤖 This commit was assisted by Gemini CLI


### PR DESCRIPTION
## 🍒 Summary

This pull request reverts the git command execution logic in `incremental_index_command.ts` back to using `execSync` instead of `spawnSync`.

This change is a direct troubleshooting step to address a persistent and unusual `ENOENT` error that occurs only when the application is run in a specific remote environment. While `spawnSync` is generally more robust, the shell invocation provided by `execSync` may inherit the execution environment in a way that circumvents the issue on the affected machine.

## 🛠️ Changes

- The `runGitCommand` helper function has been removed.
- All git operations in `incremental_index_command.ts` now use `execSync`.

## 🎙️ Prompts

- "can we go back to the original git command that worked"

🤖 This pull request was assisted by Gemini CLI
