### PR TITLE
Refactor producer to a standard commander command

### DIFF
--- a/COMMIT_MESSAGE.md
+++ b/COMMIT_MESSAGE.md
@@ -1,10 +1,15 @@
-Revert to execSync for git commands
+Refactor producer to a standard commander command
 
-- Reverts the git command execution in `incremental_index_command.ts` from `spawnSync` back to `execSync`.
-- This is a troubleshooting step to address a persistent `ENOENT` error in a specific remote environment.
+- Refactors the producer logic from a standalone script (`src/run_producer.ts`) into a standard `commander` command (`src/commands/run_producer_command.ts`).
+- This aligns the producer with the existing command structure, improving consistency and maintainability.
+- The `start:producer` npm script is updated to call the new `run-producer` command.
+- The `GCP_DEPLOYMENT_GUIDE.md` is updated to reflect the new command.
+- The `spawnSync` implementation for git commands is restored as it is the more robust solution.
 
 Prompts:
 
 - "can we go back to the original git command that worked"
+- "`npm run incremental-index` runs without errors... how can we make it work exactly the same... look at the package json"
+- "Can you please make run producer work like the rest of the commands..."
 
 🤖 This commit was assisted by Gemini CLI

--- a/docs/GCP_DEPLOYMENT_GUIDE.md
+++ b/docs/GCP_DEPLOYMENT_GUIDE.md
@@ -147,7 +147,7 @@ We will use `cron`, a standard time-based job scheduler, to run the indexer peri
     **Command Breakdown:**
     *   `*/15 * * * *`: This is the schedule, meaning "at every 15th minute."
     *   `cd /opt/semantic-code-search-indexer`: This is critical. It changes to the project directory so that `npm` and the application can find their files (`package.json`, `.env`, etc.).
-    *   `npm run start:producer`: This executes the compiled TypeScript producer.
+    *   `npm run start:producer`: This executes the producer command using `ts-node`, which is the most reliable execution method in this environment.
     *   `>> /var/log/indexer.log 2>&1`: This redirects all output (both standard output and standard error) to a log file. You must ensure this file is writable by the user running the cron job (e.g., `sudo touch /var/log/indexer.log && sudo chown your_user /var/log/indexer.log`).
 
 3.  **Save and Exit:**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "queue:list-failed": "ts-node src/index.ts queue:list-failed",
     "setup": "ts-node src/index.ts setup",
     "test": "jest",
-    "start:producer": "node dist/src/run_producer.js"
+    "start:producer": "ts-node src/index.ts run-producer"
   },
   "keywords": [],
   "author": "",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,3 +8,4 @@ export * from './monitor_queue_command';
 export * from './clear_queue_command';
 export * from './retry_failed_command';
 export * from './list_failed_command';
+export * from './run_producer_command';

--- a/src/commands/run_producer_command.ts
+++ b/src/commands/run_producer_command.ts
@@ -1,11 +1,11 @@
-import './config'; // Must be the first import
-import { incrementalIndex } from './commands/incremental_index_command';
-import { worker } from './commands/worker_command';
-import { appConfig } from './config';
-import { logger } from './utils/logger';
+import { Command } from 'commander';
+import { incrementalIndex } from './incremental_index_command';
+import { worker } from './worker_command';
+import { appConfig } from '../config';
+import { logger } from '../utils/logger';
 import path from 'path';
 
-async function main() {
+async function runProducer() {
   logger.info('Starting multi-repository producer service...');
 
   const reposToIndex = process.env.REPOSITORIES_TO_INDEX;
@@ -38,15 +38,12 @@ async function main() {
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
       logger.error(`Failed to process repository ${repoName}`, { error: errorMessage });
-      // Depending on desired behavior, you might want to continue or exit.
-      // For now, we will log the error and continue to the next repo.
     }
   }
 
   logger.info('All repositories processed. Producer service finished.');
 }
 
-main().catch(error => {
-  logger.error('An unexpected error occurred in the producer service', { error });
-  process.exit(1);
-});
+export const runProducerCommand = new Command('run-producer')
+  .description('Run the multi-repository producer service')
+  .action(runProducer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
    
   clearQueueCommand,
   retryFailedCommand,
-  listFailedCommand
+  listFailedCommand,
+  runProducerCommand
 } from './commands';
 
 const program = new Command();
@@ -30,6 +31,7 @@ program.addCommand(monitorQueueCommand);
 program.addCommand(clearQueueCommand);
 program.addCommand(retryFailedCommand);
 program.addCommand(listFailedCommand);
+program.addCommand(runProducerCommand);
 
 async function main() {
   await program.parseAsync(process.argv);


### PR DESCRIPTION
## 🍒 Summary

This pull request refactors the producer logic into a standard `commander` command to align with the project's existing architecture. This change resolves a series of stubborn `ENOENT` errors by ensuring the producer is run via `ts-node` in the same manner as all other working commands.

The `spawnSync` implementation for git commands is also restored, as it is the more robust and secure method.

## 🛠️ Changes

- The standalone `src/run_producer.ts` script has been converted into a new `run-producer` command in `src/commands/run_producer_command.ts`.
- The new command is registered in `src/index.ts`.
- The `start:producer` npm script has been updated to call the new `run-producer` command.
- The `GCP_DEPLOYMENT_GUIDE.md` has been updated to reflect the new, consistent command execution.
- The git command logic has been reverted back to the more robust `spawnSync` implementation.

## 🎙️ Prompts

- "can we go back to the original git command that worked"
- "`npm run incremental-index` runs without errors... how can we make it work exactly the same... look at the package json"
- "Can you please make run producer work like the rest of the commands..."

🤖 This pull request was assisted by Gemini CLI
