### PR TITLE
fix: Handle undefined HOME environment variable in incremental indexer

### DIFF
--- a/src/commands/incremental_index_command.ts
+++ b/src/commands/incremental_index_command.ts
@@ -34,7 +34,8 @@ interface IncrementalIndexOptions {
 }
 
 async function getQueue(options?: IncrementalIndexOptions): Promise<IQueue> {
-  const queuePath = options ? path.join(options.queueDir, 'queue.db') : path.join(appConfig.queueDir, 'queue.db');
+  const queueDir = options?.queueDir ?? appConfig.queueDir;
+  const queuePath = path.join(queueDir, 'queue.db');
   const queue = new SqliteQueue(queuePath);
   await queue.initialize();
   return queue;


### PR DESCRIPTION
## 🍒 Summary

This pull request addresses a `TypeError` in the incremental indexer that occurred when the `process.env.HOME` environment variable was not set. The fix ensures that the queue directory path is always resolved correctly by providing a reliable fallback mechanism.

## 🛠️ Changes

- Modified `src/commands/incremental_index_command.ts` to use a nullish coalescing operator (`??`) in the `getQueue` function.
- This ensures that if `options.queueDir` is `undefined`, the code safely falls back to `appConfig.queueDir`.
- This change prevents the `path.join` function from being called with an `undefined` argument, thus resolving the `TypeError`.

## 🎙️ Prompts

- "I'm getting this error with incremental index: ..."
- "Create a feature branch using the following steps: ..."
- "Create a PR using the following guidelines: ..."

🤖 This pull request was assisted by Gemini CLI
