### PR TITLE
Adds support for private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,14 @@ Clones a target repository into the `./.repos/` directory to prepare it for inde
 
 **Arguments:**
 - `<repo_url>`: The URL of the git repository to clone.
+- `--token <token>`: (Optional) A GitHub Personal Access Token for cloning private repositories.
 
 **Example:**
 ```bash
 npm run setup -- https://github.com/elastic/kibana.git
+
+# With a token for a private repository
+npm run setup -- https://github.com/my-org/my-private-repo.git --token ghp_YourTokenHere
 ```
 
 ### `npm run index`
@@ -107,6 +111,48 @@ Starts the producer worker, which scans the repository for changes and adds them
 ```bash
 npm run start:producer
 ```
+
+---
+## Private Repository Support
+
+To index private GitHub repositories, you need to provide a Personal Access Token (PAT).
+
+### Creating a GitHub Personal Access Token
+
+The recommended and most secure method is to use a **fine-grained** PAT with read-only permissions for the specific repositories you want to index.
+
+1.  Go to your GitHub **Settings** > **Developer settings** > **Personal access tokens** > **Fine-grained tokens**.
+2.  Click **Generate new token**.
+3.  Give the token a descriptive name (e.g., "Code Indexer Token").
+4.  Under **Repository access**, select **Only select repositories** and choose the private repository (or repositories) you need to index.
+5.  Under **Permissions**, go to **Repository permissions**.
+6.  Find the **Contents** permission and select **Read-only** from the dropdown.
+7.  Click **Generate token**.
+
+### Providing the Token
+
+You can provide the token in two ways:
+
+1.  **As a command-line argument (for `setup`):**
+    Use the `--token` option when running the `setup` command.
+    ```bash
+    npm run setup -- <private-repo-url> --token <your-token>
+    ```
+
+2.  **In the `.env` file (for scheduled indexing):**
+    For the scheduled `start:producer` command, you can add the token to the `REPOSITORIES_TO_INDEX` variable in your `.env` file. The format is `path:index:token`.
+
+    ```
+    # .env file
+    REPOSITORIES_TO_INDEX="/path/to/repo-one:index-one:ghp_TokenOne /path/to/repo-two:index-two:ghp_TokenTwo"
+    ```
+
+    You can also set a global `GITHUB_TOKEN` in your `.env` file as a fallback.
+
+    ```
+    # .env file
+    GITHUB_TOKEN=ghp_YourGlobalToken
+    ```
 
 ---
 ## Queue Management

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
         "p-queue": "^6.6.2",
+        "simple-git": "^3.28.0",
         "tree-sitter": "^0.25.0",
         "tree-sitter-go": "^0.25.0",
         "tree-sitter-java": "^0.23.5",
@@ -1725,6 +1726,21 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
     },
     "node_modules/@marp-team/marp-cli": {
       "version": "4.2.3",
@@ -7509,6 +7525,21 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint . --ext .ts",
     "index": "NODE_OPTIONS=--max-old-space-size=8192 ts-node src/index.ts index",
     "index-worker": "ts-node src/index.ts worker",
-    
     "queue:clear": "ts-node src/index.ts queue:clear",
     "search": "ts-node src/index.ts search",
     "incremental-index": "ts-node src/index.ts incremental-index",
@@ -43,6 +42,7 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.6.0",
     "p-queue": "^6.6.2",
+    "simple-git": "^3.28.0",
     "tree-sitter": "^0.25.0",
     "tree-sitter-go": "^0.25.0",
     "tree-sitter-java": "^0.23.5",

--- a/src/commands/start_producer_command.ts
+++ b/src/commands/start_producer_command.ts
@@ -15,9 +15,9 @@ async function startProducer(repoConfigs: string[]) {
   }
 
   for (const repoConfig of repoConfigs) {
-    const [repoPath, esIndex] = repoConfig.split(':');
+    const [repoPath, esIndex, token] = repoConfig.split(':');
     if (!repoPath || !esIndex) {
-      logger.error(`Invalid repository configuration format: "${repoConfig}". Expected "path:index". Skipping.`);
+      logger.error(`Invalid repository configuration format: "${repoConfig}". Expected "path:index[:token]". Skipping.`);
       continue;
     }
     const repoName = path.basename(repoPath);
@@ -28,6 +28,7 @@ async function startProducer(repoConfigs: string[]) {
     const options = {
       queueDir,
       elasticsearchIndex: esIndex,
+      token,
     };
 
     try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,4 +41,5 @@ export const indexingConfig = {
 export const appConfig = {
   queueDir: path.resolve(projectRoot, process.env.QUEUE_DIR || '.queue'),
   queueBaseDir: path.resolve(projectRoot, process.env.QUEUE_BASE_DIR || '.queues'),
+  githubToken: process.env.GITHUB_TOKEN,
 };


### PR DESCRIPTION
## 🍒 Summary

This pull request adds support for indexing private GitHub repositories by allowing the use of Personal Access Tokens (PATs).

## 🛠️ Changes

- Replaces the usage of `child_process` with the `simple-git` library for all Git operations, providing a more robust and secure way to interact with repositories.
- Adds a new `--token` option to the `setup` command, allowing users to provide a PAT when cloning private repositories.
- Updates the `incremental-index` command to accept a token for pulling the latest changes from private repositories.
- Modifies the `start-producer` command to support an optional token in the repository configuration, enabling scheduled indexing of private repositories.
- Includes comprehensive documentation in the `README.md` on how to create and use a fine-grained PAT for private repository access.

🤖 This pull request was assisted by Gemini CLI
