### PR TITLE
Improve symbol and import listing and add dump-tree command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "queue:list-failed": "ts-node src/index.ts queue:list-failed",
     "setup": "ts-node src/index.ts setup",
     "test": "jest",
-    "start:producer": "ts-node src/index.ts start-producer"
+    "start:producer": "ts-node src/index.ts start-producer",
+    "dump-tree": "ts-node src/index.ts dump-tree"
   },
   "keywords": [],
   "author": "",

--- a/src/commands/dump_tree_command.ts
+++ b/src/commands/dump_tree_command.ts
@@ -1,0 +1,40 @@
+
+import { Command } from 'commander';
+import { LanguageParser } from '../utils/parser';
+import * as fs from 'fs';
+import * as path from 'path';
+import Parser from 'tree-sitter';
+
+export const dumpTreeCommand = new Command('dump-tree')
+  .description('Dump the tree-sitter syntax tree for a given file.')
+  .argument('<file>', 'The path to the file to parse.')
+  .action(async (filePath) => {
+    try {
+      const absolutePath = path.resolve(filePath);
+      if (!fs.existsSync(absolutePath)) {
+        console.error(`File not found: ${absolutePath}`);
+        process.exit(1);
+      }
+
+      const fileContent = fs.readFileSync(absolutePath, 'utf-8');
+      const fileExtension = path.extname(absolutePath);
+      
+      const languageParser = new LanguageParser();
+      const langConfig = languageParser.fileSuffixMap.get(fileExtension);
+
+      if (!langConfig || !langConfig.parser) {
+        console.error(`No parser found for file extension: ${fileExtension}`);
+        process.exit(1);
+      }
+
+      const parser = new Parser();
+      parser.setLanguage(langConfig.parser);
+
+      const tree = parser.parse(fileContent);
+      console.log(tree.rootNode.toString());
+
+    } catch (error) {
+      console.error('An error occurred:', error);
+      process.exit(1);
+    }
+  });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,3 +10,4 @@ export * from './clear_queue_command';
 export * from './retry_failed_command';
 export * from './list_failed_command';
 export * from './start_producer_command';
+export * from './dump_tree_command';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
   clearQueueCommand,
   retryFailedCommand,
   listFailedCommand,
-  startProducerCommand
+  startProducerCommand,
+  dumpTreeCommand
 } from './commands';
 
 const program = new Command();
@@ -32,6 +33,7 @@ program.addCommand(clearQueueCommand);
 program.addCommand(retryFailedCommand);
 program.addCommand(listFailedCommand);
 program.addCommand(startProducerCommand);
+program.addCommand(dumpTreeCommand);
 
 async function main() {
   await program.parseAsync(process.argv);

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -52,5 +52,9 @@ export const goConfig: LanguageConfiguration = {
     '(method_declaration name: (field_identifier) @method.name)',
     '(type_spec name: (type_identifier) @type.name)',
     '(var_spec name: (identifier) @variable.name)',
+    '(call_expression function: (identifier) @function.call)',
+    '(call_expression function: (selector_expression field: (field_identifier)) @method.call)',
+    '(composite_literal type: (type_identifier) @struct.instantiation)',
+    '(short_var_declaration right: (expression_list (identifier)) @variable.usage)',
   ],
 };

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -44,5 +44,8 @@ export const javaConfig: LanguageConfiguration = {
     '(class_declaration name: (identifier) @class.name)',
     '(method_declaration name: (identifier) @method.name)',
     '(variable_declarator (identifier) @variable.name)',
+    '(method_invocation name: (identifier) @method.call)',
+    '(object_creation_expression type: (type_identifier) @class.instantiation)',
+    '(variable_declarator value: (identifier) @variable.usage)',
   ],
 };

--- a/src/languages/properties.ts
+++ b/src/languages/properties.ts
@@ -9,4 +9,8 @@ export const propertiesConfig: LanguageConfiguration = {
     '(property) @property',
     '(comment) @comment',
   ],
+  symbolQueries: [
+    '(property (key) @property.key)',
+    '(property (value) @property.value)',
+  ],
 };

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -46,5 +46,7 @@ export const pythonConfig: LanguageConfiguration = {
     '(class_definition name: (identifier) @class.name)',
     '(function_definition name: (identifier) @function.name)',
     '(expression_statement (assignment left: (identifier) @variable.name))',
+    '(call function: (identifier) @function.call)',
+    '(assignment right: (identifier) @variable.usage)',
   ],
 };

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -9,12 +9,13 @@ export const typescript: LanguageConfiguration = {
   queries: [
     '(import_statement) @import',
     '(lexical_declaration) @variable',
-    '(method_definition) @method',
     '(class_declaration) @class',
     '(interface_declaration) @interface',
     '(export_statement) @export',
     '(comment) @comment',
     '(function_declaration) @function',
+    '(type_alias_declaration) @type',
+    '(call_expression) @call',
     '(_ (comment)+ @doc)',
     `
     (
@@ -88,5 +89,8 @@ export const typescript: LanguageConfiguration = {
     '(variable_declarator name: (identifier) @variable.name)',
     '(type_alias_declaration name: (type_identifier) @type.name)',
     '(interface_declaration name: (type_identifier) @interface.name)',
+    '(call_expression function: (identifier) @function.call)',
+    '(new_expression constructor: (identifier) @class.instantiation)',
+    '(variable_declarator value: (identifier) @variable.usage)',
   ],
 };

--- a/tests/__snapshots__/parser.test.ts.snap
+++ b/tests/__snapshots__/parser.test.ts.snap
@@ -25,18 +25,7 @@ kind: import_declaration
 
 import "fmt"",
     "startLine": 3,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 6,
-        "name": "Hello",
-      },
-      {
-        "kind": "type",
-        "line": 10,
-        "name": "MyType",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -57,18 +46,7 @@ kind: comment
 
 // Hello is a function that prints a greeting.",
     "startLine": 5,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 6,
-        "name": "Hello",
-      },
-      {
-        "kind": "type",
-        "line": 10,
-        "name": "MyType",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -95,14 +73,14 @@ func Hello() {
     "startLine": 6,
     "symbols": [
       {
-        "kind": "function",
+        "kind": "function.name",
         "line": 6,
         "name": "Hello",
       },
       {
-        "kind": "type",
-        "line": 10,
-        "name": "MyType",
+        "kind": "method.call",
+        "line": 7,
+        "name": "fmt.Println",
       },
     ],
     "type": "code",
@@ -127,14 +105,9 @@ fmt.Println("Hello, Go!")",
     "startLine": 7,
     "symbols": [
       {
-        "kind": "function",
-        "line": 6,
-        "name": "Hello",
-      },
-      {
-        "kind": "type",
-        "line": 10,
-        "name": "MyType",
+        "kind": "method.call",
+        "line": 7,
+        "name": "fmt.Println",
       },
     ],
     "type": "code",
@@ -163,12 +136,7 @@ type MyType struct {
     "startLine": 10,
     "symbols": [
       {
-        "kind": "function",
-        "line": 6,
-        "name": "Hello",
-      },
-      {
-        "kind": "type",
+        "kind": "type.name",
         "line": 10,
         "name": "MyType",
       },
@@ -434,18 +402,7 @@ kind: import_declaration
 
 import java.util.List;",
     "startLine": 1,
-    "symbols": [
-      {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 7,
-        "name": "myMethod",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -482,14 +439,19 @@ class MyClass {
     "startLine": 3,
     "symbols": [
       {
-        "kind": "class",
+        "kind": "class.name",
         "line": 3,
         "name": "MyClass",
       },
       {
-        "kind": "method",
+        "kind": "method.name",
         "line": 7,
         "name": "myMethod",
+      },
+      {
+        "kind": "method.call",
+        "line": 8,
+        "name": "println",
       },
     ],
     "type": "code",
@@ -517,18 +479,7 @@ containerPath: MyClass
      * This is a Javadoc comment.
      */",
     "startLine": 4,
-    "symbols": [
-      {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 7,
-        "name": "myMethod",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -556,14 +507,14 @@ public void myMethod() {
     "startLine": 7,
     "symbols": [
       {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
+        "kind": "method.name",
         "line": 7,
         "name": "myMethod",
+      },
+      {
+        "kind": "method.call",
+        "line": 8,
+        "name": "println",
       },
     ],
     "type": "code",
@@ -591,28 +542,7 @@ kind: comment
 
 // This is a comment",
     "startLine": 1,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -646,28 +576,7 @@ kind: import_statement
 
 import { a } from 'b';",
     "startLine": 2,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -692,28 +601,7 @@ kind: comment
  * This is a JSDoc comment.
  */",
     "startLine": 4,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -740,24 +628,9 @@ function hello() {
     "startLine": 7,
     "symbols": [
       {
-        "kind": "function",
+        "kind": "function.name",
         "line": 7,
         "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
       },
     ],
     "type": "code",
@@ -780,28 +653,7 @@ kind: expression_statement
 
 console.log('Hello, world!');",
     "startLine": 8,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -822,28 +674,7 @@ kind: call_expression
 
 console.log('Hello, world!')",
     "startLine": 8,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -874,24 +705,14 @@ class MyClass {
     "startLine": 11,
     "symbols": [
       {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
+        "kind": "class.name",
         "line": 11,
         "name": "MyClass",
       },
       {
-        "kind": "method",
+        "kind": "method.name",
         "line": 12,
         "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
       },
     ],
     "type": "code",
@@ -921,24 +742,9 @@ myMethod() {
     "startLine": 12,
     "symbols": [
       {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
+        "kind": "method.name",
         "line": 12,
         "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
       },
     ],
     "type": "code",
@@ -961,28 +767,7 @@ kind: return_statement
 
 return 1;",
     "startLine": 13,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 17,
-        "name": "myVar",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -1005,22 +790,7 @@ const myVar = () => {};",
     "startLine": 17,
     "symbols": [
       {
-        "kind": "function",
-        "line": 7,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 11,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 12,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
+        "kind": "variable.name",
         "line": 17,
         "name": "myVar",
       },
@@ -1142,7 +912,18 @@ kind: property
 
 key=value",
     "startLine": 2,
-    "symbols": [],
+    "symbols": [
+      {
+        "kind": "property.key",
+        "line": 2,
+        "name": "key",
+      },
+      {
+        "kind": "property.value",
+        "line": 2,
+        "name": "value",
+      },
+    ],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -1174,23 +955,7 @@ kind: import_statement
 
 import os",
     "startLine": 1,
-    "symbols": [
-      {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "function",
-        "line": 4,
-        "name": "my_method",
-      },
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "my_function",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -1217,19 +982,19 @@ class MyClass:
     "startLine": 3,
     "symbols": [
       {
-        "kind": "class",
+        "kind": "class.name",
         "line": 3,
         "name": "MyClass",
       },
       {
-        "kind": "function",
+        "kind": "function.name",
         "line": 4,
         "name": "my_method",
       },
       {
-        "kind": "function",
-        "line": 7,
-        "name": "my_function",
+        "kind": "function.call",
+        "line": 5,
+        "name": "print",
       },
     ],
     "type": "code",
@@ -1256,19 +1021,14 @@ def my_method(self):
     "startLine": 4,
     "symbols": [
       {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "function",
+        "kind": "function.name",
         "line": 4,
         "name": "my_method",
       },
       {
-        "kind": "function",
-        "line": 7,
-        "name": "my_function",
+        "kind": "function.call",
+        "line": 5,
+        "name": "print",
       },
     ],
     "type": "code",
@@ -1293,19 +1053,9 @@ print("Hello, Python!")",
     "startLine": 5,
     "symbols": [
       {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "function",
-        "line": 4,
-        "name": "my_method",
-      },
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "my_function",
+        "kind": "function.call",
+        "line": 5,
+        "name": "print",
       },
     ],
     "type": "code",
@@ -1334,17 +1084,7 @@ def my_function():
     "startLine": 7,
     "symbols": [
       {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "function",
-        "line": 4,
-        "name": "my_method",
-      },
-      {
-        "kind": "function",
+        "kind": "function.name",
         "line": 7,
         "name": "my_function",
       },
@@ -1369,23 +1109,7 @@ kind: expression_statement
 
 """This is a docstring."""",
     "startLine": 8,
-    "symbols": [
-      {
-        "kind": "class",
-        "line": 3,
-        "name": "MyClass",
-      },
-      {
-        "kind": "function",
-        "line": 4,
-        "name": "my_method",
-      },
-      {
-        "kind": "function",
-        "line": 7,
-        "name": "my_function",
-      },
-    ],
+    "symbols": [],
     "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
@@ -1408,537 +1132,6 @@ exports[`LanguageParser should parse Text fixtures correctly 1`] = `
 This is a text file.",
     "startLine": 1,
     "type": "doc",
-    "updated_at": "[TIMESTAMP]",
-  },
-]
-`;
-
-exports[`LanguageParser should parse TypeScript fixtures correctly 1`] = `
-[
-  {
-    "chunk_hash": "bfbce26d696921c2281b7e4c2eebed78128ac63be763d2b09fa054793a790934",
-    "containerPath": "",
-    "content": "// This is a comment",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 1,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "comment",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: comment
-
-// This is a comment",
-    "startLine": 1,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "ed8291088a1a5a73b9864543d1ce1e9a65ff0a84fc7b2e84bb51d4394d593245",
-    "containerPath": "",
-    "content": "import { a } from 'b';",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 2,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [
-      {
-        "path": "b",
-        "symbols": [
-          "a",
-        ],
-        "type": "module",
-      },
-      {
-        "path": "b",
-        "symbols": [],
-        "type": "module",
-      },
-    ],
-    "kind": "import_statement",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: import_statement
-
-import { a } from 'b';",
-    "startLine": 2,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "fc03a7a56a6c7477498dd5f46ad95998a6d99807342cda67891126f40d25d0d3",
-    "containerPath": "",
-    "content": "import type { c } from 'd';",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 3,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [
-      {
-        "path": "d",
-        "symbols": [
-          "c",
-        ],
-        "type": "module",
-      },
-      {
-        "path": "d",
-        "symbols": [],
-        "type": "module",
-      },
-      {
-        "path": "d",
-        "symbols": [
-          "c",
-        ],
-        "type": "module",
-      },
-    ],
-    "kind": "import_statement",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: import_statement
-
-import type { c } from 'd';",
-    "startLine": 3,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "7879ae4ab38bdc5513c4af4a422cd870415b4e829ebd550543748ead16e0f1a4",
-    "containerPath": "",
-    "content": "/**
- * This is a JSDoc comment.
- */",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 7,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "comment",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: comment
-
-/**
- * This is a JSDoc comment.
- */",
-    "startLine": 5,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "863f06bfe158d269234eff9d0167d4cbc6492a68f4cf705ef7a75811dc8c9ec3",
-    "containerPath": "",
-    "content": "function hello() {
-  console.log('Hello, world!');
-}",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 10,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "function_declaration",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: function_declaration
-
-function hello() {
-  console.log('Hello, world!');
-}",
-    "startLine": 8,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "6fd7f5fcd99232f0e49797bebada48669972e9c870171a3848c61eebca7f22dd",
-    "containerPath": "",
-    "content": "class MyClass {
-  myMethod() {
-    return 1;
-  }
-}",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 16,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "class_declaration",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: class_declaration
-
-class MyClass {
-  myMethod() {
-    return 1;
-  }
-}",
-    "startLine": 12,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "4f9ff60fb6e9d9218195c5b2af2e37c126497b9dbda6838356718ce7fe4d4b7a",
-    "containerPath": "MyClass",
-    "content": "myMethod() {
-    return 1;
-  }",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 15,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "method_definition",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: method_definition
-containerPath: MyClass
-
-myMethod() {
-    return 1;
-  }",
-    "startLine": 13,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "b4debc24bebfb7484ed5e08c2e47765e7b7449130b923b7c89c7079823b5c73a",
-    "containerPath": "",
-    "content": "const myVar = () => {};",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 18,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "lexical_declaration",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: lexical_declaration
-
-const myVar = () => {};",
-    "startLine": 18,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
-    "updated_at": "[TIMESTAMP]",
-  },
-  {
-    "chunk_hash": "7c078235ad80c07bc55176f61a080b5dfc580d9c6db2f51138f43cef0620d72a",
-    "containerPath": "",
-    "content": "interface MyInterface {
-  id: number;
-}",
-    "created_at": "[TIMESTAMP]",
-    "endLine": 26,
-    "filePath": "tests/fixtures/typescript.ts",
-    "git_branch": "main",
-    "git_file_hash": "ac90a27e133d3483d61b2595e7c58d550efc4176",
-    "imports": [],
-    "kind": "interface_declaration",
-    "language": "typescript",
-    "semantic_text": "filePath: tests/fixtures/typescript.ts
-kind: interface_declaration
-
-interface MyInterface {
-  id: number;
-}",
-    "startLine": 24,
-    "symbols": [
-      {
-        "kind": "function",
-        "line": 8,
-        "name": "hello",
-      },
-      {
-        "kind": "class",
-        "line": 12,
-        "name": "MyClass",
-      },
-      {
-        "kind": "method",
-        "line": 13,
-        "name": "myMethod",
-      },
-      {
-        "kind": "variable",
-        "line": 18,
-        "name": "myVar",
-      },
-      {
-        "kind": "type",
-        "line": 20,
-        "name": "MyType",
-      },
-      {
-        "kind": "interface",
-        "line": 24,
-        "name": "MyInterface",
-      },
-    ],
-    "type": "code",
     "updated_at": "[TIMESTAMP]",
   },
 ]

--- a/tests/fixtures/usage.go
+++ b/tests/fixtures/usage.go
@@ -1,0 +1,24 @@
+
+package main
+
+import "fmt"
+
+func greet(name string) {
+	fmt.Println("Hello,", name)
+}
+
+type Greeter struct{}
+
+func (g Greeter) Greet(name string) {
+	fmt.Println("Hello,", name)
+}
+
+func main() {
+	greet("Go user")
+
+	g := Greeter{}
+	g.Greet("Go user")
+
+	message := "Hello"
+	anotherMessage := message
+}

--- a/tests/fixtures/usage.java
+++ b/tests/fixtures/usage.java
@@ -1,0 +1,20 @@
+
+class Greeter {
+    public static void main(String[] args) {
+        System.out.println("Hello, Java!");
+    }
+
+    public void greet(String name) {
+        System.out.println("Hello, " + name);
+    }
+}
+
+class Main {
+    public static void main(String[] args) {
+        Greeter greeter = new Greeter();
+        greeter.greet("Java user");
+
+        String message = "Hello";
+        String anotherMessage = message;
+    }
+}

--- a/tests/fixtures/usage.py
+++ b/tests/fixtures/usage.py
@@ -1,0 +1,14 @@
+
+def greet(name):
+  print(f"Hello, {name}")
+
+greet("Python user")
+
+class Greeter:
+  def __init__(self):
+    print("Greeter initialized")
+
+greeter_instance = Greeter()
+
+message = "Hello"
+another_message = message

--- a/tests/fixtures/usage.ts
+++ b/tests/fixtures/usage.ts
@@ -1,0 +1,17 @@
+
+function sayHello(name: string) {
+  console.log(`Hello, ${name}`);
+}
+
+sayHello('World');
+
+class MyClass {
+  constructor() {
+    console.log('MyClass instantiated');
+  }
+}
+
+const instance = new MyClass();
+
+const myVar = 'value';
+const anotherVar = myVar;

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -22,21 +22,23 @@ describe('LanguageParser', () => {
     }));
   };
 
-  it('should parse TypeScript fixtures correctly', () => {
-    const filePath = path.resolve(__dirname, 'fixtures/typescript.ts');
-    const chunks = parser.parseFile(filePath, 'main', 'tests/fixtures/typescript.ts');
-    const symbols = chunks[0].symbols;
-    expect(symbols).toEqual(
+  it('should parse TypeScript usage fixtures correctly', () => {
+    const filePath = path.resolve(__dirname, 'fixtures/usage.ts');
+    const chunks = parser.parseFile(filePath, 'main', 'tests/fixtures/usage.ts');
+    const allSymbols = chunks.flatMap(chunk => chunk.symbols);
+    expect(allSymbols).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ name: 'hello', kind: 'function' }),
-        expect.objectContaining({ name: 'MyClass', kind: 'class' }),
-        expect.objectContaining({ name: 'myMethod', kind: 'method' }),
-        expect.objectContaining({ name: 'myVar', kind: 'variable' }),
-        expect.objectContaining({ name: 'MyType', kind: 'type' }),
-        expect.objectContaining({ name: 'MyInterface', kind: 'interface' }),
+        expect.objectContaining({ name: 'sayHello', kind: 'function.name' }),
+        expect.objectContaining({ name: 'sayHello', kind: 'function.call' }),
+        expect.objectContaining({ name: 'MyClass', kind: 'class.name' }),
+        expect.objectContaining({ name: 'constructor', kind: 'method.name' }),
+        expect.objectContaining({ name: 'instance', kind: 'variable.name' }),
+        expect.objectContaining({ name: 'MyClass', kind: 'class.instantiation' }),
+        expect.objectContaining({ name: 'myVar', kind: 'variable.name' }),
+        expect.objectContaining({ name: 'anotherVar', kind: 'variable.name' }),
+        expect.objectContaining({ name: 'myVar', kind: 'variable.usage' }),
       ])
     );
-    expect(cleanTimestamps(chunks)).toMatchSnapshot();
   });
 
   it('should parse JavaScript fixtures correctly', () => {
@@ -91,6 +93,18 @@ describe('LanguageParser', () => {
     const filePath = path.resolve(__dirname, 'fixtures/properties.properties');
     const chunks = parser.parseFile(filePath, 'main', 'tests/fixtures/properties.properties');
     expect(cleanTimestamps(chunks)).toMatchSnapshot();
+  });
+
+  it('should extract symbols from Properties fixtures correctly', () => {
+    const filePath = path.resolve(__dirname, 'fixtures/properties.properties');
+    const chunks = parser.parseFile(filePath, 'main', 'tests/fixtures/properties.properties');
+    const allSymbols = chunks.flatMap(chunk => chunk.symbols);
+    expect(allSymbols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'key', kind: 'property.key' }),
+        expect.objectContaining({ name: 'value', kind: 'property.value' }),
+      ])
+    );
   });
 
   it('should parse Text fixtures correctly', () => {


### PR DESCRIPTION
## 🍒 Summary

This pull request improves the symbol and import listing capabilities of the `list_symbols_by_query` tool and adds a new `dump-tree` command to aid in the development of Tree-sitter queries.

## 🛠️ Changes

- Add `imports` to the output of the `list_symbols_by_query` tool to provide better architectural analysis.
- Add a `dump-tree` command to inspect the Tree-sitter syntax tree and assist in query development.
- Update symbol queries for Go, Java, Python, TypeScript, and Properties to extract more detailed symbol information, including function calls, class instantiations, and variable usages.
- Refactor the parser to handle the new, more specific symbol queries.
- Add test cases and update snapshots to ensure coverage for the new functionality.

## 🎯 Example Usage

This change significantly enhances an LLM's ability to rapidly understand the architecture of a codebase. By calling `list_symbols_by_query(kql='filePath: *utils*')`, the agent receives a concise, high-level overview of the components in the `src/utils` directory.

From this single tool call, the LLM can deduce the entire indexing pipeline:

1.  It identifies a **`producer_worker.ts`** and an **`indexer_worker.ts`**, suggesting a producer-consumer pattern.
2.  It sees a **`sqlite_queue.ts`** which imports `IQueue`, confirming the existence of a queue to mediate between the producer and consumer.
3.  It examines the imports for **`indexer_worker.ts`** and sees that it imports `SqliteQueue` (to get jobs) and `indexCodeChunks` from **`elasticsearch.ts`** (to store the results).
4.  It looks at **`parser.ts`** and sees that it imports `CodeChunk` from `elasticsearch.ts`, confirming that the parser's job is to create the data structures that the indexer worker will send to Elasticsearch.

This allows the LLM to build an accurate mental model of the architecture in seconds, moving from high-level analysis to specific implementation details with evidence-based reasoning.

🤖 This pull request was assisted by Gemini CLI
