### PR TITLE
Correctly calculate import paths for sub-repositories

### DIFF
--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -270,7 +270,7 @@ export class LanguageParser {
           let type: 'module' | 'file' = 'module';
           if (importPath.startsWith('.')) {
             const resolvedPath = path.resolve(path.dirname(filePath), importPath);
-            const gitRoot = execSync('git rev-parse --show-toplevel').toString().trim();
+            const gitRoot = execSync('git rev-parse --show-toplevel', { cwd: path.dirname(filePath) }).toString().trim();
             importPath = path.relative(gitRoot, resolvedPath);
             type = 'file';
           }


### PR DESCRIPTION
## 🍒 Summary

This pull request fixes an issue where import paths were being calculated incorrectly for projects indexed as sub-repositories. The problem was that the git root was being determined from the indexer's execution directory instead of the actual project's directory.

## 🛠️ Changes

- Updated the `git rev-parse --show-toplevel` command in `src/utils/parser.ts` to execute within the context of the file being parsed.
- This ensures that import paths are always relative to the root of the project being indexed.

## 🎙️ Prompts

- "Do you notice how the `filePath` starts with `x-path` but the paths from the `imports` starts with `.repos/kibana`. The `.repos/kibana` is the file path used in the `REPOSITORIES_TO_INDEX` environment setting. It looks like we are just removing the `/home/ccowan/semantic-code-search-indexer` but not the `.repos/kibana` portion of the path. We want `imports.path` to be relative to `/home/ccowan/semantic-code-search-indexer/.repos/kibana` (or `.repos/<project>`)."

🤖 This pull request was assisted by Gemini CLI
