### PR TITLE
Add repository context to logs

### DIFF
--- a/src/commands/worker_command.ts
+++ b/src/commands/worker_command.ts
@@ -1,23 +1,26 @@
 import { Command, Option } from 'commander';
 import { IndexerWorker } from '../utils/indexer_worker';
 import { appConfig, indexingConfig } from '../config';
-import { logger } from '../utils/logger';
+import { createLogger } from '../utils/logger';
 import { SqliteQueue } from '../utils/sqlite_queue';
 import path from 'path';
 
 interface WorkerOptions {
   queueDir: string;
   elasticsearchIndex: string;
+  repoName?: string;
+  branch?: string;
 }
 
 export async function worker(concurrency: number = 1, watch: boolean = false, options?: WorkerOptions) {
+  const logger = createLogger(options?.repoName && options?.branch ? { name: options.repoName, branch: options.branch } : undefined);
   logger.info('Starting indexer worker process', { concurrency, ...options });
 
-  const queuePath = options ? path.join(options.queueDir, 'queue.db') : path.join(appConfig.queueDir, 'queue.db');
+  const queuePath = options?.queueDir ? path.join(options.queueDir, 'queue.db') : path.join(appConfig.queueDir, 'queue.db');
   const queue = new SqliteQueue(queuePath);
   await queue.initialize();
 
-  const indexerWorker = new IndexerWorker(queue, indexingConfig.batchSize, concurrency, watch, options?.elasticsearchIndex);
+  const indexerWorker = new IndexerWorker(queue, indexingConfig.batchSize, concurrency, watch, logger, options?.elasticsearchIndex);
 
   await indexerWorker.start();
 }
@@ -26,6 +29,8 @@ export const workerCommand = new Command('worker')
   .description('Start a single indexer worker for development')
   .addOption(new Option('--concurrency <number>', 'Number of parallel workers to run').default(1).argParser(parseInt))
   .addOption(new Option('--watch', 'Run the worker in watch mode'))
+  .addOption(new Option('--repoName <name>', 'Name of the repository being indexed'))
+  .addOption(new Option('--branch <branch>', 'Branch of the repository being indexed'))
   .action(async (options) => {
-    await worker(options.concurrency, options.watch);
+    await worker(options.concurrency, options.watch, options);
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -75,7 +75,14 @@ if (elasticsearchConfig.logging && process.env.NODE_ENV !== 'test') {
   }
 }
 
-function log(level: LogLevel, message: string, metadata: object = {}) {
+
+
+interface RepoInfo {
+  name: string;
+  branch: string;
+}
+
+function log(level: LogLevel, message: string, metadata: object = {}, repoInfo?: RepoInfo) {
   if (isSilent) {
     return;
   }
@@ -89,7 +96,10 @@ function log(level: LogLevel, message: string, metadata: object = {}) {
       dataset: 'semantic.codesearch',
     },
     codesearch: {
-      ...getGitInfo(),
+      indexer: {
+        ...getGitInfo(),
+      },
+      repo: repoInfo,
     },
     host: {
       hostname: os.hostname(),
@@ -120,15 +130,19 @@ function log(level: LogLevel, message: string, metadata: object = {}) {
   }
 }
 
-export const logger = {
-  info: (message: string, metadata?: object) => log(LogLevel.INFO, message, metadata),
-  warn: (message: string, metadata?: object) => log(LogLevel.WARN, message, metadata),
-  error: (message: string, metadata?: object) => log(LogLevel.ERROR, message, metadata),
-  debug: (message: string, metadata?: object) => log(LogLevel.DEBUG, message, metadata),
-  set silent(value: boolean) {
-    isSilent = value;
-  },
-  get silent() {
-    return isSilent;
-  }
-};
+export function createLogger(repoInfo?: RepoInfo) {
+  return {
+    info: (message: string, metadata?: object) => log(LogLevel.INFO, message, metadata, repoInfo),
+    warn: (message: string, metadata?: object) => log(LogLevel.WARN, message, metadata, repoInfo),
+    error: (message: string, metadata?: object) => log(LogLevel.ERROR, message, metadata, repoInfo),
+    debug: (message: string, metadata?: object) => log(LogLevel.DEBUG, message, metadata, repoInfo),
+    set silent(value: boolean) {
+      isSilent = value;
+    },
+    get silent() {
+      return isSilent;
+    }
+  };
+}
+
+export const logger = createLogger();

--- a/src/utils/producer_worker.ts
+++ b/src/utils/producer_worker.ts
@@ -5,8 +5,12 @@
  * `LanguageParser`, and then sends the resulting code chunks back to the main
  * thread.
  */
-import { parentPort } from 'worker_threads';
+import { parentPort, workerData } from 'worker_threads';
 import { LanguageParser } from './parser';
+import { createLogger } from './logger';
+
+const { repoName, gitBranch: repoBranch } = workerData;
+const logger = createLogger({ name: repoName, branch: repoBranch });
 
 const languageParser = new LanguageParser();
 
@@ -21,6 +25,7 @@ parentPort?.on('message', ({ filePath, gitBranch, relativePath }: { filePath: st
     parentPort?.postMessage({ status: 'success', data: chunks, filePath });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    logger.error('Failed to parse file', { file: filePath, error: errorMessage });
     parentPort?.postMessage({ status: 'failure', error: errorMessage, filePath });
   }
 });

--- a/tests/indexer_worker.test.ts
+++ b/tests/indexer_worker.test.ts
@@ -2,6 +2,7 @@ import { IndexerWorker } from '../src/utils/indexer_worker';
 import { InMemoryQueue } from '../src/utils/in_memory_queue';
 import * as elasticsearch from '../src/utils/elasticsearch';
 import { CodeChunk } from '../src/utils/elasticsearch';
+import { logger } from '../src/utils/logger';
 
 // Mock the elasticsearch module
 jest.mock('../src/utils/elasticsearch', () => ({
@@ -34,7 +35,7 @@ describe('IndexerWorker', () => {
     queue = new InMemoryQueue();
     // Use a very short polling interval for tests
     // Note: The worker's internal polling interval is hardcoded, so this test will rely on advancing timers.
-    worker = new IndexerWorker(queue, 10, 1, false, testIndex);
+    worker = new IndexerWorker(queue, 10, 1, false, logger, testIndex);
     (elasticsearch.indexCodeChunks as jest.Mock).mockClear();
   });
 


### PR DESCRIPTION
## 🍒 Summary

This pull request introduces per-repository logging, allowing for the easy filtering of logs by the repository being indexed.

## 🛠️ Changes

- Refactored the logger to use a factory pattern (`createLogger`) that accepts repository information.
- Updated the `index` command to create a logger with the context of the repository being indexed.
- Propagated the repository context to producer and indexer workers.
- Updated tests to reflect the changes.
- Fixed a bug in the `worker` command where `queueDir` was not being correctly resolved.

## 🎙️ Prompts

- "I would like the codesearch attribute to be about the repo that's being index and not the indexer's repo. For example, if I'm indexing `.repos/kibana` I want to be able to tell which repo the indexer and it's workers are working on. Right now it's impossible to filter the logs by the repo name. Ideally the the `codesearch` would have a `repo` attribute that was set to the name of the repo (not the github url) and the `branch` of the repo being indexed. Currently it appears to be the repo of the indexer."
- "What's the new command for index-worker and the options I need to pass"
- "I'm getting this error: TypeError: The "path" argument must be of type string. Received undefined"

🤖 This pull request was assisted by Gemini CLI
