### PR TITLE
chore: adds ELASTICSEARCH_HOST, ELASTICSEARCH_USERNAME

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ const projectRoot = findProjectRoot(__dirname);
 export const elasticsearchConfig = {
   endpoint: process.env.ELASTICSEARCH_ENDPOINT || process.env.ELASTICSEARCH_HOST,
   cloudId: process.env.ELASTICSEARCH_CLOUD_ID,
-  username: process.env.ELASTICSEARCH_USER,
+  username: process.env.ELASTICSEARCH_USER || process.env.ELASTICSEARCH_USERNAME,
   password: process.env.ELASTICSEARCH_PASSWORD,
   apiKey: process.env.ELASTICSEARCH_API_KEY,
   model: process.env.ELASTICSEARCH_MODEL || '.elser_model_2',


### PR DESCRIPTION
## Context

Having the indexer read `ELASTICSEARCH_HOST` and `ELASTICSEARCH_USERNAME` makes it easier for our deployment framework to orchestrate ES secrets.

## Implementation details

Adds `ELASTICSEARCH_HOST` as fallback.