### PR TITLE
Fix settings index to use custom index name instead of default

### DIFF
--- a/src/commands/index_command.ts
+++ b/src/commands/index_command.ts
@@ -52,7 +52,7 @@ export async function index(directory: string, clean: boolean, options?: IndexOp
 
   await setupElser();
   await createIndex(options?.elasticsearchIndex);
-  await createSettingsIndex();
+  await createSettingsIndex(options?.elasticsearchIndex);
 
   const gitRoot = execSync('git rev-parse --show-toplevel', { cwd: directory }).toString().trim();
   const ig = ignore();


### PR DESCRIPTION
## 🍒 Summary

When running `bulk:reindex` with a custom index name, the settings index was always created as `code_chunk_settings` instead of using the custom index name as a base (e.g., `kibana-code-search-2025-10-15_settings`).

## 🛠️ Changes

- Pass `options?.elasticsearchIndex` parameter to `createSettingsIndex()` in the index command
- Ensures settings index is created with the pattern `{custom-index-name}_settings` instead of always using `code_chunk_settings`
- Fixes bulk:reindex command to correctly create settings indices based on target index names

## 🎙️ Prompts

- "When I run `build:reindex` instead of creating the settings as I would expect using the target index as the base it's creating `code_chunk_settings`. For example, if i'm indexing into `kibana-code-search-2025-10-15` I would expect to get `kibana-code-search-2025-10-15_settings`"

🤖 This pull request was assisted by Cursor