### PR TITLE
Add OpenTelemetry diagnostic logging and fix header parsing for base64-encoded API keys

### DIFF
--- a/tests/otel_provider.test.ts
+++ b/tests/otel_provider.test.ts
@@ -1,4 +1,81 @@
 // tests/otel_provider.test.ts
+import { parseHeaders } from '../src/utils/otel_provider';
+
+describe('parseHeaders', () => {
+  it('should parse simple key=value pairs', () => {
+    const result = parseHeaders('key1=value1,key2=value2');
+    expect(result).toEqual({
+      key1: 'value1',
+      key2: 'value2',
+    });
+  });
+
+  it('should handle values containing equals signs', () => {
+    const result = parseHeaders('Authorization=ApiKey dGVzdDp0ZXN0==');
+    expect(result).toEqual({
+      Authorization: 'ApiKey dGVzdDp0ZXN0==',
+    });
+  });
+
+  it('should handle multiple headers with values containing equals signs', () => {
+    const result = parseHeaders('Authorization=ApiKey abc123==,content-type=application/json');
+    expect(result).toEqual({
+      Authorization: 'ApiKey abc123==',
+      'content-type': 'application/json',
+    });
+  });
+
+  it('should handle base64 encoded values', () => {
+    const result = parseHeaders('x-api-key=dGVzdDp0ZXN0Cg==,Authorization=Bearer token123==');
+    expect(result).toEqual({
+      'x-api-key': 'dGVzdDp0ZXN0Cg==',
+      Authorization: 'Bearer token123==',
+    });
+  });
+
+  it('should trim whitespace from keys and values', () => {
+    const result = parseHeaders('  key1  =  value1  ,  key2  =  value2  ');
+    expect(result).toEqual({
+      key1: 'value1',
+      key2: 'value2',
+    });
+  });
+
+  it('should return empty object for empty string', () => {
+    const result = parseHeaders('');
+    expect(result).toEqual({});
+  });
+
+  it('should skip malformed entries without equals sign', () => {
+    const result = parseHeaders('key1=value1,malformed,key2=value2');
+    expect(result).toEqual({
+      key1: 'value1',
+      key2: 'value2',
+    });
+  });
+
+  it('should skip entries with empty keys', () => {
+    const result = parseHeaders('=value1,key2=value2');
+    expect(result).toEqual({
+      key2: 'value2',
+    });
+  });
+
+  it('should skip entries with empty values', () => {
+    const result = parseHeaders('key1=,key2=value2');
+    expect(result).toEqual({
+      key2: 'value2',
+    });
+  });
+
+  it('should handle complex real-world header strings', () => {
+    const result = parseHeaders('Authorization=ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVoT3k6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==,x-elastic-product-origin=kibana');
+    expect(result).toEqual({
+      Authorization: 'ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVoT3k6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==',
+      'x-elastic-product-origin': 'kibana',
+    });
+  });
+});
 
 describe('OTel Provider', () => {
   const originalEnv = process.env;
@@ -125,8 +202,26 @@ describe('OTel Provider', () => {
     
     // Verify standard attributes are still present
     expect(attributes['service.name']).toBeDefined();
-    expect(attributes['host.name']).toBeDefined();
-    expect(attributes['host.arch']).toBeDefined();
+    // The detectors add various attributes - just verify we have some
+    expect(Object.keys(attributes).length).toBeGreaterThan(3);
+  });
+
+  it('should respect OTEL_RESOURCE_ATTRIBUTES environment variable', async () => {
+    process.env.OTEL_LOGGING_ENABLED = 'true';
+    process.env.OTEL_RESOURCE_ATTRIBUTES = 'deployment.environment=staging,team=platform,custom.key=custom-value';
+    const { getLoggerProvider } = await import('../src/utils/otel_provider');
+    const provider = getLoggerProvider();
+    expect(provider).not.toBeNull();
+
+    // Access the resource attributes through the provider's _sharedState
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resource = (provider as any)._sharedState.resource;
+    const attributes = resource.attributes;
+
+    // Verify OTEL_RESOURCE_ATTRIBUTES were added
+    expect(attributes['deployment.environment']).toBe('staging');
+    expect(attributes['team']).toBe('platform');
+    expect(attributes['custom.key']).toBe('custom-value');
   });
 });
 


### PR DESCRIPTION
## 🍒 Summary

This PR adds OpenTelemetry diagnostic logging capabilities and fixes a critical bug in header parsing that prevented base64-encoded API keys from working correctly. It also adds support for the standard `OTEL_RESOURCE_ATTRIBUTES` environment variable, enabling users to attach custom attributes to all telemetry data.

## 🛠️ Changes

- **Fix header parsing bug**: Updated `parseHeaders()` to split only on the first `=` character, allowing values to contain `=` (e.g., base64-encoded API keys ending in `==`)
- **Add OTEL diagnostic logging**: Introduced `OTEL_LOG_LEVEL` environment variable to enable SDK diagnostic output (`debug`, `info`, `warn`, `error`)
- **Add OTEL_RESOURCE_ATTRIBUTES support**: Implemented parsing and merging of standard OpenTelemetry resource attributes from environment variables
- **Export parseHeaders for testing**: Made the function exportable to enable comprehensive unit testing
- **Add comprehensive tests**: Added 10 tests for `parseHeaders()` covering edge cases, base64 values, and malformed input
- **Add OTEL_RESOURCE_ATTRIBUTES test**: Verified that environment variable attributes are correctly merged with defaults
- **Remove host-specific attributes**: Removed `ATTR_HOST_NAME`, `ATTR_HOST_ARCH`, `ATTR_HOST_TYPE`, and `ATTR_OS_TYPE` in favor of SDK auto-detection
- **Update documentation**: Added troubleshooting section with OTEL debugging guidance and updated environment variable documentation with examples
- **Clarify header format**: Documented the `key1=value1,key2=value2` format for both headers and resource attributes

## 🎙️ Prompts

- "Using `gh` can you read PR 34 from `elastic/semantic-metadata-layer` repo and apply the same fixes to the indexer in this repo?"

🤖 This pull request was assisted by Cursor

