### PR TITLE
ci: skip Docker registry push on pull requests

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -41,6 +41,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       - name: Login to Docker registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # ratchet:docker/login-action@v3
         with:
           registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
@@ -64,7 +65,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           sbom: true
           provenance: mode=max
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Modified the docker_release workflow to only build (not push) Docker images on pull requests, avoiding authentication errors when Docker registry credentials are unavailable for PRs. On main branch pushes, the workflow continues to build and push as before.