### PR TITLE
feat(producer): idempotency on incremental

### DIFF
--- a/src/commands/incremental_index_command.ts
+++ b/src/commands/incremental_index_command.ts
@@ -17,6 +17,7 @@ import {
   METRIC_STATUS_FAILURE,
   LANGUAGE_UNKNOWN,
 } from '../utils/constants';
+import { index } from './index_command';
 
 interface IncrementalIndexOptions {
   queueDir: string;
@@ -52,7 +53,14 @@ export async function incrementalIndex(directory: string, options?: IncrementalI
   const lastCommitHash = await getLastIndexedCommit(gitBranch, options?.elasticsearchIndex);
 
   if (!lastCommitHash) {
-    logger.warn('No previous commit hash found. Please run a full index first.', { gitBranch });
+    logger.info('No previous commit hash found. Running full index first.', { gitBranch });
+    await index(directory, false, {
+      queueDir: options?.queueDir,
+      elasticsearchIndex: options?.elasticsearchIndex,
+      repoName: options?.repoName,
+      branch: options?.branch,
+    });
+    logger.info('Full index complete. Incremental indexing is now available for future runs.');
     return;
   }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,4 +1,10 @@
 // tests/config.test.ts
+
+// Mock dotenv to prevent loading .env file during tests
+jest.mock('dotenv', () => ({
+  config: jest.fn(),
+}));
+
 describe('elasticsearchConfig', () => {
   const originalEnv = process.env;
 


### PR DESCRIPTION
## Context for changes

When managing full or incremental indexes, the entity responsible for determining which command to execute for each repository must know beforehand whether the last indexed commit is recorded in the `_settings` index. Since this state is known at the time of calling [this](https://github.com/elastic/semantic-code-search-indexer/blob/d7646ad7c9730fbea65e9c653b2967a7d288a72f/src/commands/incremental_index_command.ts#L52-L57) function, it would be very helpful for the incremental index's operation if it were idempotent and didn't require a full index beforehand.

https://github.com/elastic/semantic-code-search-indexer/blob/d7646ad7c9730fbea65e9c653b2967a7d288a72f/src/commands/incremental_index_command.ts#L52-L57

## Proposal

Instead of requiring users to manually run a full index first, the indexer should handle this automatically. Running `npm run incremental-index -- .repos/my-repo` should produce consistent output whether a full index has been done or not.

Potentially, to consolidate this into one single command.

## Additional changes

For a dev with a different `.env`, config tests would fail. I've mocked `dotenv` so it's consistent across development environments. 