### PR TITLE
fix(ci): docker release in forks

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -28,8 +28,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "release-scsi-${{ github.ref }}"
-  cancel-in-progress: true
+  group: "release-scsi-${{ github.sha }}"
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -41,6 +41,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # ratchet:docker/setup-buildx-action@v3
 
       - name: Login to Docker registry
+        if: ${{ github.event.pull_request.head.repo.full_name == 'elastic/semantic-code-search-indexer' && github.event.number != '' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # ratchet:docker/login-action@v3
         with:
           registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
@@ -48,6 +49,7 @@ jobs:
           password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
+        if: ${{ github.event.pull_request.head.repo.full_name == 'elastic/semantic-code-search-indexer' && github.event.number != '' }}
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # ratchet:docker/metadata-action@v5
         with:
@@ -64,7 +66,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event.pull_request.head.repo.full_name == 'elastic/semantic-code-search-indexer' && github.event.number != '' }}
           sbom: true
           provenance: mode=max
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What does this PR fix

https://github.com/elastic/semantic-code-search-indexer/actions/runs/19413582583/job/55538489945?pr=105

CI errors occur when executing workflows in forks.

## What changes are introduced

In forks, it will only build and will not attempt to log into the artifact registry.