### PR TITLE
fix(ci): docker release in forks

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -28,7 +28,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "release-scsi-${{ github.ref }}"
+  group: "release-scsi-${{ github.sha }}"
   cancel-in-progress: true
 jobs:
   docker:


### PR DESCRIPTION
## What does this PR fix

https://github.com/elastic/semantic-code-search-indexer/actions/runs/19413582583/job/55538489945?pr=105

CI errors occur when executing workflows in forks.

## What changes are introduced

In forks, it will only build and will not attempt to log into the artifact registry.