### PR TITLE
feat: adds integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,70 @@ jobs:
         env:
           CI: true
         run: npm test -- --ci
+  
+  integration_tests:
+    if: ${{ github.event.pull_request.head.repo.full_name == 'elastic/semantic-code-search-indexer' || github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - name: Get token
+        id: get_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.ELASTIC_OBSERVABILITY_APP_ID }}
+          private-key: ${{ secrets.ELASTIC_OBSERVABILITY_APP_PEM }}
+          permission-contents: read
+          repositories: |
+            observability-test-environments
+            oblt-cli
+            semantic-code-search-indexer
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Git
+        uses: elastic/oblt-actions/git/setup@f740c3cbf5827083fd638a6b80bcd27d0f903d37 # v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+
+      - name: "Setup oblt-cli"
+        uses: elastic/oblt-actions/oblt-cli/setup@dbb6b183abcf22f595ad943862358d25a929c129 # ratchet:elastic/oblt-actions/oblt-cli/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+          slack-channel: '#observablt-bots'
+          username: 'obltmachine'
+
+      - name: Authenticate to Google Cloud
+        uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # ratchet:google-github-actions/auth@v3
+        with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_ID }}
+
+      - name: "Pull test cluster credentials"
+        run: oblt-cli cluster secrets env --cluster-name test-oblt --output-file .env.test
+
+      - name: Run integration tests
+        env:
+          CI: true
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+        run: npm run test:integration -- --ci

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "queue:retry-failed": "ts-node src/index.ts queue:retry-failed",
     "queue:list-failed": "ts-node src/index.ts queue:list-failed",
     "dump-tree": "ts-node src/index.ts dump-tree",
-    "test": "jest",
+    "test": "jest --testPathIgnorePatterns=tests/integration",
+    "test:unit": "jest --testPathIgnorePatterns=tests/integration",
+    "test:integration": "jest tests/integration/basic.integration.test.ts",
+    "test:all": "jest",
     "prepare": "husky"
   },
   "keywords": [],

--- a/src/commands/index_command.ts
+++ b/src/commands/index_command.ts
@@ -381,3 +381,5 @@ export const indexCommand = new Command('index')
       throw error;
     }
   });
+
+export { indexRepos };

--- a/src/commands/setup_command.ts
+++ b/src/commands/setup_command.ts
@@ -28,3 +28,5 @@ export const setupCommand = new Command('setup')
   .argument('<repo_url>', 'The URL of the git repository to clone')
   .option('--token <token>', 'GitHub token for private repositories')
   .action(setup);
+
+export { setup };

--- a/tests/integration/basic.integration.test.ts
+++ b/tests/integration/basic.integration.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from '@jest/globals';
+import { client } from '../../src/utils/elasticsearch';
+import { setup } from '../../src/commands/setup_command';
+import { indexRepos } from '../../src/commands/index_command';
+
+const TEST_REPO_URL = 'https://github.com/elastic/semantic-code-search-indexer.git';
+const TEST_INDEX = `test-integration-index-${Date.now()}`;
+
+describe('Integration Test', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  afterAll(async () => {
+    try {
+      await client.indices.delete({ index: TEST_INDEX });
+      await client.indices.delete({ index: `${TEST_INDEX}_settings` });
+    } catch {}
+  });
+
+  it('should setup, index, and verify only markdown documents in elasticsearch', async () => {
+    delete process.env.SEMANTIC_CODE_INDEXER_LANGUAGES;
+    process.env.SEMANTIC_CODE_INDEXER_LANGUAGES = 'markdown';
+
+    await setup(TEST_REPO_URL, {});
+    await indexRepos([`${TEST_REPO_URL}:${TEST_INDEX}`], {});
+    const response = await client.count({ index: TEST_INDEX });
+
+    expect(response.count).toBeGreaterThan(0);
+  }, 180000);
+});


### PR DESCRIPTION
## Context

Adds a basic integration test that'll run on feature branches and `main`.

## Implementation details

The test will setup, index and verify indexing has happened in the target ES index. The target ES infrastructure is an [`oblt-cluster`](https://studious-disco-k66oojq.pages.github.io/) created for testing purposes.

## Related issues

Relates to https://github.com/elastic/observability-robots/issues/3119