### PR TITLE
fix: OpenTelemetry service name being overridden to "unknown_service:node"

### DIFF
--- a/src/utils/otel_provider.ts
+++ b/src/utils/otel_provider.ts
@@ -128,13 +128,14 @@ function parseResourceAttributes(resourceAttributesString: string): Record<strin
  * @returns A Resource instance with all detected and custom attributes
  */
 function createResource(defaultAttributes: Record<string, string | number> = {}): Resource {
-  // Start with default attributes
-  let resource = new Resource(defaultAttributes);
+  // Start with SDK defaults (telemetry.sdk.*, etc.) but exclude service.name
+  // which defaults to "unknown_service:node"
+  let resource = Resource.default();
 
-  // Merge with SDK defaults (telemetry.sdk.*, service.name, etc.)
-  resource = resource.merge(Resource.default());
+  // Merge with our custom default attributes (includes service.name from config)
+  resource = resource.merge(new Resource(defaultAttributes));
 
-  // Parse and merge OTEL_RESOURCE_ATTRIBUTES if present
+  // Parse and merge OTEL_RESOURCE_ATTRIBUTES if present (highest priority)
   const otelResourceAttributes = process.env.OTEL_RESOURCE_ATTRIBUTES;
   if (otelResourceAttributes) {
     const envAttributes = parseResourceAttributes(otelResourceAttributes);


### PR DESCRIPTION
## Problem
When `OTEL_SERVICE_NAME` environment variable was set (e.g., `OTEL_SERVICE_NAME=scsi`), OpenTelemetry logs and metrics were still showing `service.name: "unknown_service:node"` instead of the configured service name.

## Root Cause
The issue was in the `createResource()` function's merge order:
1. Custom attributes (including correct service name) were set first
2. `Resource.default()` was merged second, **overwriting** the service name with `"unknown_service:node"`
3. `OTEL_RESOURCE_ATTRIBUTES` was processed last, but didn't include service name

## Solution
Fixed the merge order to preserve the configured service name:
1. Start with SDK defaults (`Resource.default()`)
2. Merge custom attributes (including service name from `otelConfig.serviceName`)  
3. Apply `OTEL_RESOURCE_ATTRIBUTES` as highest priority overrides

## Result
OpenTelemetry logs and metrics now correctly show the configured service name (e.g., `service.name: "scsi"`) instead of `"unknown_service:node"`.

## Changes
- Modified `createResource()` function in `src/utils/otel_provider.ts` to fix resource attribute merge order
- Updated comments to clarify the merge priority