### PR TITLE
fix: optimize partial bulk failure handling to only requeue failed documents

### DIFF
--- a/src/utils/elasticsearch.ts
+++ b/src/utils/elasticsearch.ts
@@ -3,6 +3,8 @@ import {
   ClusterHealthResponse,
   QueryDslQueryContainer,
   BulkOperationContainer,
+  BulkOperationType,
+  BulkResponseItem,
 } from '@elastic/elasticsearch/lib/api/types';
 import { elasticsearchConfig, indexingConfig } from '../config';
 export { elasticsearchConfig };
@@ -229,26 +231,32 @@ export interface CodeChunk {
   updated_at: string;
 }
 
-interface ErroredDocument {
-  status: number;
-  // The structure of the error object from the Elasticsearch client can be complex and varied, making it difficult to type statically.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error: any;
-  operation: { index: { _index: string } };
-  document: CodeChunk;
+/**
+ * Result of a bulk indexing operation, separating succeeded and failed documents.
+ */
+export interface BulkIndexResult {
+  /** Documents that were successfully indexed */
+  succeeded: CodeChunk[];
+  /** Documents that failed to index with their errors */
+  failed: { chunk: CodeChunk; error: unknown }[];
 }
 
 /**
  * Indexes an array of code chunks into Elasticsearch.
  *
  * This function uses the Elasticsearch bulk API to efficiently index a large
- * number of documents at once.
+ * number of documents at once. Returns a result object with succeeded and failed
+ * documents to allow granular handling of partial failures.
+ *
+ * On complete failures (network errors, cluster unavailable), returns all chunks
+ * as failed rather than throwing.
  *
  * @param chunks An array of `CodeChunk` objects to index.
+ * @returns A `BulkIndexResult` with succeeded and failed documents.
  */
-export async function indexCodeChunks(chunks: CodeChunk[], index?: string): Promise<void> {
+export async function indexCodeChunks(chunks: CodeChunk[], index?: string): Promise<BulkIndexResult> {
   if (chunks.length === 0) {
-    return;
+    return { succeeded: [], failed: [] };
   }
 
   const indexName = index || defaultIndexName;
@@ -268,32 +276,42 @@ export async function indexCodeChunks(chunks: CodeChunk[], index?: string): Prom
     const bulkResponse = await client.bulk(bulkOptions);
     logger.info(`Bulk operation completed for ${chunks.length} chunks`);
 
-    if (bulkResponse.errors) {
-      const erroredDocuments: ErroredDocument[] = [];
-      // The `action` object from the Elasticsearch bulk response has a dynamic structure
-      // (e.g., { index: { ... } }, { create: { ... } }) which is difficult to type
-      // statically without overly complex type guards.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      bulkResponse.items.forEach((action: any, i: number) => {
-        const operation = Object.keys(action)[0];
-        if (action[operation].error) {
-          erroredDocuments.push({
-            status: action[operation].status,
-            error: action[operation].error,
-            operation: operations[i * 2] as { index: { _index: string } },
-            document: operations[i * 2 + 1] as CodeChunk,
-          });
-        }
+    const succeeded: CodeChunk[] = [];
+    const failed: { chunk: CodeChunk; error: unknown }[] = [];
+
+    bulkResponse.items.forEach((action: Partial<Record<BulkOperationType, BulkResponseItem>>, i: number) => {
+      const operationType = Object.keys(action)[0] as BulkOperationType;
+      const result = action[operationType];
+      const chunk = operations[i * 2 + 1] as CodeChunk;
+
+      if (result?.error) {
+        failed.push({
+          chunk,
+          error: result.error,
+        });
+      } else {
+        succeeded.push(chunk);
+      }
+    });
+
+    if (failed.length > 0) {
+      logger.error(`Partial bulk failure: ${failed.length}/${chunks.length} documents failed`, {
+        errors: JSON.stringify(
+          failed.map((f) => ({ chunk_hash: f.chunk.chunk_hash, error: f.error })),
+          null,
+          2
+        ),
       });
-      logger.error('Errors during bulk indexing:', { errors: JSON.stringify(erroredDocuments, null, 2) });
-      throw new Error(
-        `Bulk indexing failed: ${erroredDocuments.length} of ${chunks.length} documents had errors. ` +
-          `First error: ${JSON.stringify(erroredDocuments[0]?.error)}`
-      );
     }
+
+    return { succeeded, failed };
   } catch (error) {
+    // Complete failure (network, cluster down, etc.) - all documents failed
     logger.error('Exception during bulk indexing:', { error });
-    throw error;
+    return {
+      succeeded: [],
+      failed: chunks.map((chunk) => ({ chunk, error })),
+    };
   }
 }
 

--- a/tests/unit/elasticsearch.test.ts
+++ b/tests/unit/elasticsearch.test.ts
@@ -29,7 +29,7 @@ describe('indexCodeChunks', () => {
     mockBulk = vi.spyOn(elasticsearch.client, 'bulk');
   });
 
-  it('should not throw when bulk indexing succeeds', async () => {
+  it('should return all chunks as succeeded when bulk indexing succeeds', async () => {
     const mockBulkResponse = {
       errors: false,
       items: [
@@ -46,12 +46,15 @@ describe('indexCodeChunks', () => {
     mockBulk.mockResolvedValue(mockBulkResponse);
 
     const chunks = [MOCK_CHUNK];
+    const result = await elasticsearch.indexCodeChunks(chunks);
 
-    await expect(elasticsearch.indexCodeChunks(chunks)).resolves.not.toThrow();
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.failed).toHaveLength(0);
+    expect(result.succeeded[0].chunk_hash).toBe('chunk_hash_1');
     expect(mockBulk).toHaveBeenCalledTimes(1);
   });
 
-  it('should throw error when bulk indexing fails', async () => {
+  it('should return failed chunks when bulk indexing has errors', async () => {
     const mockBulkResponse = {
       errors: true,
       items: [
@@ -70,14 +73,19 @@ describe('indexCodeChunks', () => {
     mockBulk.mockResolvedValue(mockBulkResponse);
 
     const chunks = [MOCK_CHUNK];
+    const result = await elasticsearch.indexCodeChunks(chunks);
 
-    await expect(elasticsearch.indexCodeChunks(chunks)).rejects.toThrow(
-      /Bulk indexing failed: 1 of 1 documents had errors/
-    );
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].chunk.chunk_hash).toBe('chunk_hash_1');
+    expect(result.failed[0].error).toEqual({
+      type: 'mapper_parsing_exception',
+      reason: 'failed to parse field [semantic_text]',
+    });
     expect(mockBulk).toHaveBeenCalledTimes(1);
   });
 
-  it('should include first error details in error message', async () => {
+  it('should include error details in failed results', async () => {
     const mockBulkResponse = {
       errors: true,
       items: [
@@ -97,21 +105,17 @@ describe('indexCodeChunks', () => {
     mockBulk.mockResolvedValue(mockBulkResponse);
 
     const chunks = [MOCK_CHUNK];
+    const result = await elasticsearch.indexCodeChunks(chunks);
 
-    try {
-      await elasticsearch.indexCodeChunks(chunks);
-      expect.fail('Expected indexCodeChunks to throw an error');
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      if (error instanceof Error) {
-        expect(error.message).toContain('Bulk indexing failed: 1 of 1 documents had errors');
-        expect(error.message).toContain('index_not_found_exception');
-        expect(error.message).toContain('no such index [missing-index]');
-      }
-    }
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].error).toMatchObject({
+      type: 'index_not_found_exception',
+      reason: 'no such index [missing-index]',
+    });
   });
 
-  it('should handle multiple errors and report count correctly', async () => {
+  it('should separate succeeded and failed documents in partial failure', async () => {
     const mockChunk2: CodeChunk = {
       ...MOCK_CHUNK,
       chunk_hash: 'chunk_hash_2',
@@ -158,21 +162,23 @@ describe('indexCodeChunks', () => {
     mockBulk.mockResolvedValue(mockBulkResponse);
 
     const chunks = [MOCK_CHUNK, mockChunk2, mockChunk3];
+    const result = await elasticsearch.indexCodeChunks(chunks);
 
-    try {
-      await elasticsearch.indexCodeChunks(chunks);
-      expect.fail('Expected indexCodeChunks to throw an error');
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      if (error instanceof Error) {
-        expect(error.message).toContain('Bulk indexing failed: 2 of 3 documents had errors');
-        expect(error.message).toContain('mapper_parsing_exception');
-      }
-    }
+    // First chunk succeeded
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.succeeded[0].chunk_hash).toBe('chunk_hash_1');
+
+    // Second and third chunks failed
+    expect(result.failed).toHaveLength(2);
+    expect(result.failed[0].chunk.chunk_hash).toBe('chunk_hash_2');
+    expect(result.failed[1].chunk.chunk_hash).toBe('chunk_hash_3');
   });
 
-  it('should return early when chunks array is empty', async () => {
-    await elasticsearch.indexCodeChunks([]);
+  it('should return empty arrays when chunks array is empty', async () => {
+    const result = await elasticsearch.indexCodeChunks([]);
+
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
     expect(mockBulk).not.toHaveBeenCalled();
   });
 
@@ -195,10 +201,25 @@ describe('indexCodeChunks', () => {
     mockBulk.mockResolvedValue(mockBulkResponse);
 
     const chunks = [MOCK_CHUNK];
+    const result = await elasticsearch.indexCodeChunks(chunks);
 
-    await expect(elasticsearch.indexCodeChunks(chunks)).rejects.toThrow(
-      /Bulk indexing failed: 1 of 1 documents had errors/
-    );
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].error).toMatchObject({
+      type: 'version_conflict_engine_exception',
+    });
+  });
+
+  it('should return all chunks as failed on network/connection error', async () => {
+    mockBulk.mockRejectedValue(new Error('Connection refused'));
+
+    const chunks = [MOCK_CHUNK];
+    const result = await elasticsearch.indexCodeChunks(chunks);
+
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].chunk.chunk_hash).toBe('chunk_hash_1');
+    expect(result.failed[0].error).toBeInstanceOf(Error);
   });
 });
 


### PR DESCRIPTION
Closes #125

## Summary

- `indexCodeChunks()` now returns `BulkIndexResult` with `succeeded` and `failed` arrays instead of throwing on partial failures
- `processBatch()` commits succeeded documents immediately and only requeues actually failed documents
- Previously, any bulk error requeued the entire batch - safe due to idempotent `_id`s but caused redundant re-indexing of already-succeeded documents

## Test plan

- [x] Unit tests updated for new return type
- [x] Added test case: "should only requeue failed documents on partial bulk failure"
- [x] All 282 tests pass
- [x] Lint clean