### PR TITLE
feat: automatically create -repo alias when indexing (with index name normalization)

### DIFF
--- a/tests/unit/elasticsearch.test.ts
+++ b/tests/unit/elasticsearch.test.ts
@@ -1,9 +1,10 @@
 import { Client } from '@elastic/elasticsearch';
-import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest';
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import type { Mock } from 'vitest';
 
 import * as elasticsearch from '../../src/utils/elasticsearch';
 import { CodeChunk } from '../../src/utils/elasticsearch';
+import * as loggerModule from '../../src/utils/logger';
 
 const MOCK_CHUNK: CodeChunk = {
   type: 'code',
@@ -247,6 +248,446 @@ describe('indexCodeChunks', () => {
     expect(result.failed).toHaveLength(1);
     expect(result.failed[0].chunk.chunk_hash).toBe('chunk_hash_1');
     expect(result.failed[0].error).toBeInstanceOf(Error);
+  });
+});
+
+describe('createRepoAlias', () => {
+  let mockExistsAlias: Mock;
+  let mockExists: Mock;
+  let mockPutAlias: Mock;
+  let mockLoggerInfo: Mock;
+  let mockLoggerWarn: Mock;
+  let mockLoggerError: Mock;
+  let mockClient: Client;
+
+  beforeEach(() => {
+    // Create a mock client with all necessary methods
+    mockExistsAlias = vi.fn();
+    mockExists = vi.fn();
+    mockPutAlias = vi.fn();
+    mockClient = {
+      indices: {
+        existsAlias: mockExistsAlias,
+        exists: mockExists,
+        putAlias: mockPutAlias,
+      },
+    } as unknown as Client;
+    elasticsearch.setClient(mockClient);
+
+    // Mock logger
+    mockLoggerInfo = vi.spyOn(loggerModule.logger, 'info');
+    mockLoggerWarn = vi.spyOn(loggerModule.logger, 'warn');
+    mockLoggerError = vi.spyOn(loggerModule.logger, 'error');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('SHOULD create alias when index exists and alias does not', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns true)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'test-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'test-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'test-index' });
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: 'test-index',
+      name: 'test-index-repo',
+    });
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Creating alias "test-index-repo" pointing to index "test-index"...');
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Successfully created alias "test-index-repo"');
+  });
+
+  it('SHOULD skip alias creation when alias already exists', async () => {
+    mockExistsAlias.mockResolvedValue(true);
+
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'test-index-repo' });
+    expect(mockExists).not.toHaveBeenCalled();
+    expect(mockPutAlias).not.toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Alias "test-index-repo" already exists.');
+  });
+
+  it('SHOULD skip alias creation when index does not exist', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns false)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(false);
+
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'test-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'test-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'test-index' });
+    expect(mockPutAlias).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Cannot create alias "test-index-repo": index "test-index" does not exist.'
+    );
+  });
+
+  it('SHOULD skip alias creation when an index with alias name already exists', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns true - conflict!)
+    mockExists.mockResolvedValueOnce(true);
+
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'test-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'test-index-repo' });
+    // Should not check if target index exists or try to create alias
+    expect(mockExists).not.toHaveBeenCalledWith({ index: 'test-index' });
+    expect(mockPutAlias).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Cannot create alias "test-index-repo": an index with this name already exists. ' +
+        'The alias cannot be created because index names and alias names must be unique.'
+    );
+  });
+
+  it('SHOULD use default index name when no index parameter provided', async () => {
+    const defaultIndex = elasticsearch.elasticsearchConfig.index;
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns true)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    await elasticsearch.createRepoAlias();
+
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: `${defaultIndex}-repo` });
+    expect(mockExists).toHaveBeenCalledWith({ index: `${defaultIndex}-repo` });
+    expect(mockExists).toHaveBeenCalledWith({ index: defaultIndex });
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: defaultIndex,
+      name: `${defaultIndex}-repo`,
+    });
+  });
+
+  it('SHOULD handle alias creation errors gracefully without throwing', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns true)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const error = new Error('Alias creation failed');
+    mockPutAlias.mockRejectedValue(error);
+
+    // Should not throw
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockLoggerError).toHaveBeenCalledWith('Failed to create alias "test-index-repo":', { error });
+  });
+
+  it('SHOULD handle existsAlias check errors gracefully', async () => {
+    const error = new Error('Check failed');
+    mockExistsAlias.mockRejectedValue(error);
+
+    // Should not throw
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockLoggerError).toHaveBeenCalledWith('Failed to create alias "test-index-repo":', { error });
+  });
+
+  it('SHOULD handle exists check for alias name index errors gracefully', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    const error = new Error('Index check failed');
+    mockExists.mockRejectedValue(error);
+
+    // Should not throw
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockLoggerError).toHaveBeenCalledWith('Failed to create alias "test-index-repo":', { error });
+  });
+
+  it('SHOULD handle exists check for target index errors gracefully', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (throws error)
+    mockExists.mockResolvedValueOnce(false).mockRejectedValueOnce(new Error('Index check failed'));
+
+    // Should not throw
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockLoggerError).toHaveBeenCalledWith('Failed to create alias "test-index-repo":', {
+      error: expect.any(Error),
+    });
+  });
+
+  it('SHOULD reject invalid index names', async () => {
+    // Empty string should use default index name (which is valid), so we need to check that
+    // For truly invalid names, validation should prevent alias creation
+    await elasticsearch.createRepoAlias('invalid/index');
+    await elasticsearch.createRepoAlias('_invalid');
+
+    // These should not call existsAlias because validation fails first
+    expect(mockExistsAlias).not.toHaveBeenCalled();
+    expect(mockPutAlias).not.toHaveBeenCalled();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith('Cannot create alias: invalid index name "invalid/index"');
+    expect(mockLoggerWarn).toHaveBeenCalledWith('Cannot create alias: invalid index name "_invalid"');
+  });
+
+  it('SHOULD reject alias names that would be invalid', async () => {
+    // Index name that would create an invalid alias
+    await elasticsearch.createRepoAlias('test/repo');
+
+    expect(mockExistsAlias).not.toHaveBeenCalled();
+    expect(mockPutAlias).not.toHaveBeenCalled();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith('Cannot create alias: invalid index name "test/repo"');
+  });
+
+  it('SHOULD reject uppercase index names', async () => {
+    await elasticsearch.createRepoAlias('MyIndex');
+    await elasticsearch.createRepoAlias('KIBANA');
+
+    expect(mockExistsAlias).not.toHaveBeenCalled();
+    expect(mockPutAlias).not.toHaveBeenCalled();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith('Cannot create alias: invalid index name "MyIndex"');
+    expect(mockLoggerWarn).toHaveBeenCalledWith('Cannot create alias: invalid index name "KIBANA"');
+  });
+
+  it('SHOULD handle empty string by using default index name', async () => {
+    const defaultIndex = elasticsearch.elasticsearchConfig.index;
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns true)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    await elasticsearch.createRepoAlias('');
+
+    // Should use default index name, not fail
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: `${defaultIndex}-repo` });
+    expect(mockExists).toHaveBeenCalledWith({ index: `${defaultIndex}-repo` });
+    expect(mockExists).toHaveBeenCalledWith({ index: defaultIndex });
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: defaultIndex,
+      name: `${defaultIndex}-repo`,
+    });
+  });
+
+  it('SHOULD reject alias names that exceed 255 character limit', async () => {
+    // Create an index name that, after normalization and adding -repo, would exceed 255 chars
+    const longName = 'a'.repeat(251); // 251 chars + '-repo' (5) = 256 chars
+    await elasticsearch.createRepoAlias(longName);
+
+    expect(mockExistsAlias).not.toHaveBeenCalled();
+    expect(mockPutAlias).not.toHaveBeenCalled();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      `Cannot create alias: alias name "${longName}-repo" exceeds 255 character limit`
+    );
+  });
+
+  it('SHOULD normalize -repo segments from index name for alias creation', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if index with alias name exists (conflict check) - returns false (no conflict)
+    // Second call: check if normalized target index exists - returns true (index 'kibana' exists)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    // Index name with multiple -repo segments
+    // After normalization in createRepoAlias: kibana-repo-repo-repo → kibana (baseIndexName) → alias kibana-repo
+    // The function uses the normalized baseIndexName for index existence check and alias creation
+    // So it checks if index 'kibana' exists and creates alias 'kibana-repo' → 'kibana'
+    await elasticsearch.createRepoAlias('kibana-repo-repo-repo');
+
+    // Should create alias 'kibana-repo' (normalized), pointing to normalized index 'kibana'
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'kibana-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'kibana-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'kibana' });
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: 'kibana',
+      name: 'kibana-repo',
+    });
+  });
+
+  it('SHOULD handle index name that already ends with -repo correctly', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if index with alias name exists (conflict check) - returns false (no conflict)
+    // Second call: check if normalized target index exists - returns true (index 'kibana' exists)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    // Index name that already ends with -repo
+    // createRepoAlias normalizes the index name: 'kibana-repo' → 'kibana' (baseIndexName)
+    // It uses the normalized name (baseIndexName) for index existence check and alias creation
+    // So it checks if index 'kibana' exists and creates alias 'kibana-repo' → 'kibana'
+    // This succeeds because alias name ('kibana-repo') differs from index name ('kibana')
+    await elasticsearch.createRepoAlias('kibana-repo');
+
+    // Should log warning about normalization
+    expect(mockLoggerWarn).toHaveBeenCalledWith('Index name "kibana-repo" was normalized to "kibana" ');
+    // Should check if alias exists
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'kibana-repo' });
+    // Should check for conflict (index with alias name exists) - no conflict
+    expect(mockExists).toHaveBeenCalledWith({ index: 'kibana-repo' });
+    // Should check if normalized target index exists
+    expect(mockExists).toHaveBeenCalledWith({ index: 'kibana' });
+    // Should create alias pointing to normalized index name
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: 'kibana',
+      name: 'kibana-repo',
+    });
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Creating alias "kibana-repo" pointing to index "kibana"...');
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Successfully created alias "kibana-repo"');
+  });
+
+  it('SHOULD handle race condition when alias is created concurrently', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns true)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    // Simulate 409 conflict (alias created by another process)
+    const conflictError = {
+      meta: { statusCode: 409 },
+      body: { error: { type: 'resource_already_exists_exception' } },
+    };
+    mockPutAlias.mockRejectedValue(conflictError);
+
+    // Should not throw, should log info message
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockPutAlias).toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'Alias "test-index-repo" was created by another process or already exists.'
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD handle illegal_argument_exception as race condition', async () => {
+    mockExistsAlias.mockResolvedValue(false);
+    // First call: check if alias name index exists (returns false)
+    // Second call: check if target index exists (returns true)
+    mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const illegalArgError = {
+      meta: { statusCode: 400 },
+      body: { error: { type: 'illegal_argument_exception' } },
+    };
+    mockPutAlias.mockRejectedValue(illegalArgError);
+
+    await elasticsearch.createRepoAlias('test-index');
+
+    expect(mockPutAlias).toHaveBeenCalled();
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      'Alias "test-index-repo" was created by another process or already exists.'
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});
+
+describe('createIndex integration with createRepoAlias', () => {
+  let mockExists: Mock;
+  let mockCreate: Mock;
+  let mockExistsAlias: Mock;
+  let mockPutAlias: Mock;
+
+  beforeEach(() => {
+    // Create a mock client with all necessary methods
+    mockExists = vi.fn();
+    mockCreate = vi.fn();
+    mockExistsAlias = vi.fn();
+    mockPutAlias = vi.fn();
+    const mockClient = {
+      indices: {
+        exists: mockExists,
+        create: mockCreate,
+        existsAlias: mockExistsAlias,
+        putAlias: mockPutAlias,
+      },
+    } as unknown as Client;
+    elasticsearch.setClient(mockClient);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    elasticsearch.setClient(undefined);
+  });
+
+  it('SHOULD create alias after creating new index', async () => {
+    // First call (from createIndex) returns false (index doesn't exist yet)
+    // Second call (from createRepoAlias) checks if alias name index exists (returns false)
+    // Third call (from createRepoAlias) checks if target index exists (returns true, index was just created)
+    mockExists
+      .mockResolvedValueOnce(false) // For createIndex check
+      .mockResolvedValueOnce(false) // For createRepoAlias alias name check
+      .mockResolvedValueOnce(true); // For createRepoAlias target index check
+    mockCreate.mockResolvedValue({ acknowledged: true });
+    mockExistsAlias.mockResolvedValue(false);
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    await elasticsearch.createIndex('new-index');
+
+    expect(mockExists).toHaveBeenCalledWith({ index: 'new-index' });
+    expect(mockCreate).toHaveBeenCalled();
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'new-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'new-index-repo' });
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: 'new-index',
+      name: 'new-index-repo',
+    });
+  });
+
+  it('SHOULD create alias for existing index if alias does not exist', async () => {
+    // First call (from createIndex) returns true (index exists)
+    // Second call (from createRepoAlias) checks if alias name index exists (returns false)
+    // Third call (from createRepoAlias) checks if target index exists (returns true)
+    mockExists
+      .mockResolvedValueOnce(true) // For createIndex check
+      .mockResolvedValueOnce(false) // For createRepoAlias alias name check
+      .mockResolvedValueOnce(true); // For createRepoAlias target index check
+    mockExistsAlias.mockResolvedValue(false); // Alias does not exist
+    mockPutAlias.mockResolvedValue({ acknowledged: true });
+
+    await elasticsearch.createIndex('existing-index');
+
+    expect(mockExists).toHaveBeenCalledWith({ index: 'existing-index' });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'existing-index-repo' });
+    expect(mockExists).toHaveBeenCalledWith({ index: 'existing-index-repo' });
+    expect(mockPutAlias).toHaveBeenCalledWith({
+      index: 'existing-index',
+      name: 'existing-index-repo',
+    });
+  });
+
+  it('SHOULD skip alias creation for existing index if alias already exists', async () => {
+    mockExists.mockResolvedValue(true); // Index exists
+    mockExistsAlias.mockResolvedValue(true); // Alias already exists
+
+    await elasticsearch.createIndex('existing-index');
+
+    expect(mockExists).toHaveBeenCalledWith({ index: 'existing-index' });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockExistsAlias).toHaveBeenCalledWith({ name: 'existing-index-repo' });
+    expect(mockPutAlias).not.toHaveBeenCalled();
+  });
+
+  it('SHOULD handle alias creation errors without failing index creation', async () => {
+    // First call (from createIndex) returns false (index doesn't exist yet)
+    // Second call (from createRepoAlias) checks if alias name index exists (returns false)
+    // Third call (from createRepoAlias) checks if target index exists (returns true, index was just created)
+    mockExists
+      .mockResolvedValueOnce(false) // For createIndex check
+      .mockResolvedValueOnce(false) // For createRepoAlias alias name check
+      .mockResolvedValueOnce(true); // For createRepoAlias target index check
+    mockCreate.mockResolvedValue({ acknowledged: true });
+    mockExistsAlias.mockResolvedValue(false);
+    const aliasError = new Error('Alias creation failed');
+    mockPutAlias.mockRejectedValue(aliasError);
+
+    // Index creation should succeed even if alias creation fails
+    await elasticsearch.createIndex('test-index');
+
+    expect(mockCreate).toHaveBeenCalled();
+    expect(mockPutAlias).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #130 

## Summary

This PR automatically creates a `<indexName>-repo` alias when indexing repositories, eliminating the need for manual alias creation and enabling seamless discovery by the MCP server. The implementation includes intelligent index name normalization to ensure alias creation always works.

## Flows and Execution Paths

### Flow 1: Normal CLI Flow (Most Common)

```
User Command:
  npm run index -- kibana

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ 1. parseRepoArg('kibana')                                    │
  │    ├─ repoName: 'kibana'                                    │
  │    ├─ rawIndexName: 'kibana' (from repoName)               │
  │    ├─ normalizedIndexName: 'kibana' (no -repo to strip)    │
  │    └─ Returns: { indexName: 'kibana', ... }                 │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 2. createIndex('kibana')                                     │
  │    ├─ Creates index: 'kibana'                                │
  │    └─ Calls: createRepoAlias('kibana')                      │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 3. createRepoAlias('kibana')                                  │
  │    ├─ baseIndexName = removeRepoSegments('kibana')          │
  │    │  └─ Returns: 'kibana' (no change)                      │
  │    ├─ aliasName = 'kibana-repo'                             │
  │    ├─ Checks: alias 'kibana-repo' exists? → No              │
  │    ├─ Checks: index 'kibana-repo' exists? → No              │
  │    ├─ Checks: index 'kibana' exists? → Yes                   │
  │    └─ Creates alias: 'kibana-repo' → 'kibana' ✅            │
  └─────────────────────────────────────────────────────────────┘

Result:
  Index: 'kibana'
  Alias: 'kibana-repo' points to index 'kibana'
```

### Flow 2: CLI Flow with Custom Index Name (No -repo)

```
User Command:
  npm run index -- kibana:my-custom-index

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ 1. parseRepoArg('kibana:my-custom-index')                    │
  │    ├─ repoName: 'kibana'                                    │
  │    ├─ rawIndexName: 'my-custom-index'                       │
  │    ├─ normalizedIndexName: 'my-custom-index' (no -repo)     │
  │    └─ Returns: { indexName: 'my-custom-index', ... }        │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 2. createIndex('my-custom-index')                            │
  │    ├─ Creates index: 'my-custom-index'                       │
  │    └─ Calls: createRepoAlias('my-custom-index')              │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 3. createRepoAlias('my-custom-index')                        │
  │    ├─ baseIndexName = 'my-custom-index' (no change)          │
  │    ├─ aliasName = 'my-custom-index-repo'                    │
  │    └─ Creates alias: 'my-custom-index-repo' → 'my-custom-index' ✅
  └─────────────────────────────────────────────────────────────┘

Result:
  Index: 'my-custom-index'
  Alias: 'my-custom-index-repo' points to index 'my-custom-index'
```

### Flow 3: CLI Flow with Index Name Ending in -repo (Normalization)

```
User Command:
  npm run index -- kibana:kibana-repo

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ 1. parseRepoArg('kibana:kibana-repo')                       │
  │    ├─ repoName: 'kibana'                                    │
  │    ├─ rawIndexName: 'kibana-repo'                           │
  │    ├─ normalizedIndexName = removeRepoSegments('kibana-repo')│
  │    │  └─ Returns: 'kibana' (strips all -repo)               │
  │    ├─ ⚠️  Logs: "Index name 'kibana-repo' normalized to 'kibana'"
  │    └─ Returns: { indexName: 'kibana', ... }                 │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 2. createIndex('kibana')                                    │
  │    ├─ Creates index: 'kibana'                               │
  │    └─ Calls: createRepoAlias('kibana')                       │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 3. createRepoAlias('kibana')                                 │
  │    ├─ baseIndexName = 'kibana' (no change)                   │
  │    ├─ aliasName = 'kibana-repo'                              │
  │    └─ Creates alias: 'kibana-repo' → 'kibana' ✅              │
  └─────────────────────────────────────────────────────────────┘

Result:
  Index: 'kibana' (normalized from 'kibana-repo')
  Alias: 'kibana-repo' points to index 'kibana'
  ⚠️  Warning logged during normalization
```

### Flow 4: CLI Flow with Multiple -repo Segments

```
User Command:
  npm run index -- kibana:kibana-repo-repo-repo

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ 1. parseRepoArg('kibana:kibana-repo-repo-repo')            │
  │    ├─ rawIndexName: 'kibana-repo-repo-repo'                 │
  │    ├─ normalizedIndexName = removeRepoSegments(...)        │
  │    │  └─ While loop: strips all trailing -repo             │
  │    │     'kibana-repo-repo-repo' → 'kibana-repo-repo'       │
  │    │     'kibana-repo-repo' → 'kibana-repo'                 │
  │    │     'kibana-repo' → 'kibana'                           │
  │    │     Returns: 'kibana'                                  │
  │    ├─ ⚠️  Logs: "Index name 'kibana-repo-repo-repo' normalized to 'kibana'"
  │    └─ Returns: { indexName: 'kibana', ... }                 │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 2. createIndex('kibana')                                    │
  │    └─ Creates alias: 'kibana-repo' → 'kibana' ✅             │
  └─────────────────────────────────────────────────────────────┘

Result:
  Index: 'kibana' (normalized from 'kibana-repo-repo-repo')
  Alias: 'kibana-repo' points to index 'kibana'
```

### Flow 5: Direct API Call Flow (Programmatic)

```
Code:
  await createRepoAlias('kibana');

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ createRepoAlias('kibana')                                   │
  │ ├─ baseIndexName = removeRepoSegments('kibana')             │
  │ │  └─ Returns: 'kibana' (no change)                         │
  │ ├─ aliasName = 'kibana-repo'                                │
  │ ├─ Checks: index 'kibana' exists? → Yes                     │
  │ └─ Creates alias: 'kibana-repo' → 'kibana' ✅               │
  └─────────────────────────────────────────────────────────────┘

Result:
  Alias: 'kibana-repo' points to index 'kibana'
  (No normalization warning - index name unchanged)
```

### Flow 6: Direct API Call with Problematic Index Name (Edge Case)

```
Code:
  await createRepoAlias('kibana-repo');

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ createRepoAlias('kibana-repo')                              │
  │ ├─ baseIndexName = removeRepoSegments('kibana-repo')        │
  │ │  └─ Returns: 'kibana' (strips -repo)                     │
  │ ├─ aliasName = 'kibana-repo'                                │
  │ ├─ ⚠️  Logs: "Index name 'kibana-repo' normalized to 'kibana'"
  │ ├─ Checks: aliasName !== baseIndexName? → Yes               │
  │ │  └─ Checks if index 'kibana-repo' exists (conflict check) │
  │ ├─ Checks: index 'kibana' exists? → Yes (normalized name)  │
  │ └─ Creates alias: 'kibana-repo' → 'kibana' ✅               │
  └─────────────────────────────────────────────────────────────┘

Result:
  ✅ Alias creation succeeds!
  - Checks if index 'kibana' exists (normalized name)
  - Creates alias 'kibana-repo' → 'kibana' (different names, ES accepts)
  ⚠️  Warning logged about normalization
  ℹ️  In normal CLI flow, parseRepoArg normalizes first, so this edge case is handled the same way
```

### Flow 7: Existing Index Flow (Idempotent Alias Creation)

```
Scenario:
  Index 'kibana' already exists (created before this feature)

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ 1. createIndex('kibana')                                    │
  │    ├─ Checks: index 'kibana' exists? → Yes                  │
  │    ├─ Logs: "Index 'kibana' already exists"                 │
  │    └─ Calls: createRepoAlias('kibana')                      │
  └─────────────────────────────────────────────────────────────┘
                          │
                          ▼
  ┌─────────────────────────────────────────────────────────────┐
  │ 2. createRepoAlias('kibana')                                │
  │    ├─ Checks: alias 'kibana-repo' exists? → No              │
  │    ├─ Checks: index 'kibana' exists? → Yes                  │
  │    └─ Creates alias: 'kibana-repo' → 'kibana' ✅             │
  └─────────────────────────────────────────────────────────────┘

Result:
  Index: 'kibana' (pre-existing)
  Alias: 'kibana-repo' points to existing index 'kibana' (alias newly created)
```

### Flow 8: Conflict Detection (Index with Alias Name Exists)

```
Scenario:
  Index 'kibana-repo' already exists (legacy index)
  User runs: npm run index -- kibana

Execution:
  ┌─────────────────────────────────────────────────────────────┐
  │ 1. parseRepoArg('kibana') → indexName: 'kibana'             │
  │ 2. createIndex('kibana') → Creates index 'kibana'          │
  │ 3. createRepoAlias('kibana')                               │
  │    ├─ aliasName = 'kibana-repo'                             │
  │    ├─ Checks: aliasName !== baseIndexName? → Yes            │
  │    ├─ Checks: index 'kibana-repo' exists? → Yes ⚠️          │
  │    └─ ⚠️  Logs: "Cannot create alias: index with this name exists"
  │       Returns early (no alias created)                      │
  └─────────────────────────────────────────────────────────────┘

Result:
  Index: 'kibana' (created)
  Alias: Not created (conflict detected)
  ⚠️  Warning logged about conflict
```

## Key Design Decisions

### Why Normalize at Two Levels?

1. **`parseRepoArg()` normalization** (CLI entry point):
   - Normalizes user-provided index names before index creation
   - Ensures index names never contain `-repo` segments
   - Logs warning when normalization occurs

2. **`createRepoAlias()` normalization** (defensive):
   - Handles direct API calls that bypass `parseRepoArg()`
   - Ensures alias calculation always works correctly
   - Uses normalized name for all index operations (existence check, alias creation)
   - Logs warning when normalization occurs (prevents silent normalization)

### Why Strip ALL -repo Segments?

Elasticsearch does not allow an alias to have the same name as an index. If we kept `-repo` in the index name:
- Index: `kibana-repo`
- Alias: `kibana-repo` → ❌ ES rejects (same name)

By stripping all `-repo` segments:
- Index: `kibana` (normalized)
- Alias: `kibana-repo` → ✅ ES accepts (different names)

## ⚠️ Breaking Change - Index Name Normalization

**Index names with `-repo` segments are now normalized to remove all trailing `-repo` segments.**

This means:
- `kibana-repo` → normalized to `kibana` (index name)
- `kibana-repo-repo-repo` → normalized to `kibana` (index name)
- `kibana` → stays `kibana` (no normalization needed)

**Why this breaking change?** Elasticsearch does not allow an alias to have the same name as an index. If we kept `-repo` in the index name (e.g., `kibana-repo`), we couldn't create the `kibana-repo` alias. By stripping all `-repo` segments from index names, we ensure:
1. The index name is clean (e.g., `kibana`)
2. The alias can be created successfully (e.g., `kibana-repo` pointing to `kibana`)

**Impact:**
- Existing indices with `-repo` segments will continue to work, but new indexing operations will use the normalized name
- If you have an index named `my-repo-repo` and run `npm run index -- /path/to/repo:my-repo-repo`, it will create/use index `my` instead
- You may need to manually migrate data if you want to preserve the old index name
- A warning is logged when normalization occurs: `Index name "X" was normalized to "Y"`

## Testing

All tests pass (81/81):
- ✅ Index name normalization (stripping all -repo segments)
- ✅ Alias creation when index exists and alias does not
- ✅ Idempotent behavior (skip when alias already exists)
- ✅ Conflict detection (skip when index with alias name exists)
- ✅ Validation (skip when target index does not exist)
- ✅ Default index name usage
- ✅ Empty string handling
- ✅ Uppercase validation
- ✅ Length limit validation (255 chars)
- ✅ Race condition handling (409 conflicts, concurrent creation)
- ✅ Error handling (all error paths including `invalid_alias_name_exception`)
- ✅ Integration with `createIndex()` (new and existing indices)
- ✅ Normalization logging consistency (no double logging in CLI flow)
- ✅ Direct API calls with non-normalized index names (Flow 6 edge case)

## Related Issues

- Complements [elastic/semantic-code-search-mcp-server#34](https://github.com/elastic/semantic-code-search-mcp-server/pull/34) (MCP server dual discovery strategy)
- Enables automatic index discovery without manual alias creation
