### PR TITLE
fix(tests): prevent parallel SQLite failures in sqlite_queue.test.ts

### DIFF
--- a/tests/unit/sqlite_queue.test.ts
+++ b/tests/unit/sqlite_queue.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
-import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import os from 'os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { SqliteQueue } from '../../src/utils/sqlite_queue';
 import { CodeChunk } from '../../src/utils/elasticsearch';
@@ -53,15 +54,13 @@ const MOCK_CHUNK_2: CodeChunk = {
 };
 
 describe('SqliteQueue', () => {
-  const queueDir = '.test-queue';
-  const dbPath = path.join(queueDir, 'queue.db');
+  let queueDir: string;
+  let dbPath: string;
   let queue: SqliteQueue;
 
   beforeEach(async () => {
-    if (fs.existsSync(queueDir)) {
-      fs.rmSync(queueDir, { recursive: true, force: true });
-    }
-    fs.mkdirSync(queueDir, { recursive: true });
+    queueDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-queue-test-'));
+    dbPath = path.join(queueDir, 'queue.db');
     queue = new SqliteQueue({ dbPath });
     await queue.initialize();
   });
@@ -71,10 +70,6 @@ describe('SqliteQueue', () => {
     if (fs.existsSync(queueDir)) {
       fs.rmSync(queueDir, { recursive: true, force: true });
     }
-  });
-
-  afterAll(() => {
-    // No need to close here as it's handled in afterEach
   });
 
   it('should dequeue multiple documents', async () => {


### PR DESCRIPTION
**Problem:**
The `SqliteQueue` unit tests (`sqlite_queue.test.ts`) used a single hardcoded `.test-queue/` directory. Under Vitest's default forking pool + fileParallelism, multiple test workers raced on the same filesystem path, causing flaky failures:
- `disk I/O error`
- `database is locked`
- `ENOTEMPTY: Directory not empty`

**Fix:**
Switch to per-test temp directories via `os.tmpdir() + fs.mkdtempSync()`, matching the pattern already used by the passing `sqlite_queue_concurrency.test.ts`.

**Verification:**
Full test suite: `npm test` --> **364 passed, 0 failed** (previously 6 failures)

Also includes a manual native binding rebuild for the newly added PLpgSQL dependency (`@derekstride/tree-sitter-sql`), whose install hook is broken on macOS with recent Node versions due to a stale `tree-sitter generate` call.